### PR TITLE
fix: turbo race condition

### DIFF
--- a/apps/portfolio/turbo.json
+++ b/apps/portfolio/turbo.json
@@ -34,6 +34,9 @@
     },
     "test:lint:stylelint": {
       "dependsOn": ["//#install:modules"]
+    },
+    "test:types": {
+      "dependsOn": ["build"]
     }
   }
 }

--- a/apps/sessions-demo/turbo.json
+++ b/apps/sessions-demo/turbo.json
@@ -10,6 +10,9 @@
     },
     "start:prod": {
       "env": ["ADDRESS_LOOKUP_TABLE_ADDRESS", "SOLANA_RPC", "SPONSOR_KEY"]
+    },
+    "test:types": {
+      "dependsOn": ["build"]
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -160,7 +160,7 @@
       "dependsOn": ["//#install:modules", "^build"]
     },
     "test:types": {
-      "dependsOn": ["//#install:modules", "^build", "build:idl", "build"]
+      "dependsOn": ["//#install:modules", "^build", "build:idl"]
     },
     "test:unit": {
       "dependsOn": ["//#install:modules", "^build"]

--- a/turbo.json
+++ b/turbo.json
@@ -160,7 +160,7 @@
       "dependsOn": ["//#install:modules", "^build"]
     },
     "test:types": {
-      "dependsOn": ["//#install:modules", "^build", "build:idl"]
+      "dependsOn": ["//#install:modules", "^build", "build:idl", "build"]
     },
     "test:unit": {
       "dependsOn": ["//#install:modules", "^build"]


### PR DESCRIPTION
There's a race condition between `@fogo/sessions-demo#build` and `@fogo/sessions-demo#test:types` because test:types checks some types inside `.next`