### PR TITLE
feat: shorten instruction discriminator

### DIFF
--- a/programs/session-manager/src/lib.rs
+++ b/programs/session-manager/src/lib.rs
@@ -18,6 +18,7 @@ pub mod intents;
 pub mod session_manager {
     use super::*;
 
+    #[instruction(discriminator = [0])]
     pub fn start_session<'info>(
         ctx: Context<'_, '_, '_, 'info, StartSession<'info>>,
     ) -> Result<()> {


### PR DESCRIPTION
By default anchor assigns an 8 byte discriminator to instructions, which is derived from the instruction name.
These 8 bytes are the first 8 bytes of the instruction payload and are used by the program to understand which task it needs to execute.
Since a frequent problem on SVM is transaction size, I prefer to set a 1 byte discriminator manually.