### PR TITLE
chore: add getter for extra fields

### DIFF
--- a/packages/sessions-sdk-rs/src/lib.rs
+++ b/packages/sessions-sdk-rs/src/lib.rs
@@ -95,7 +95,10 @@ pub struct Extra(Vec<ExtraItem>); // Anchor IDL generation doesn't handle vec of
 
 impl Extra {
     pub fn get(&self, key: &str) -> Option<&str> {
-        self.0.iter().find(|item| item.0 == key).map(|item| item.1.as_str())
+        self.0
+            .iter()
+            .find(|item| item.0 == key)
+            .map(|item| item.1.as_str())
     }
 }
 


### PR DESCRIPTION
This removes a warning that we had when building the crate.
