### PR TITLE
fix: ensure styling is consistent and handle swr mutations

### DIFF
--- a/apps/sessions-demo/src/components/Home/use-airdrop.ts
+++ b/apps/sessions-demo/src/components/Home/use-airdrop.ts
@@ -8,7 +8,6 @@ import {
 } from "@solana/spl-token";
 import { PublicKey } from "@solana/web3.js";
 import { useCallback } from "react";
-import { mutate } from "swr";
 
 import type { Transaction } from "./use-transaction-log";
 import { useAsync } from "../../hooks/use-async";
@@ -47,13 +46,6 @@ export const useAirdrop = (
       signature: result.signature,
       success: result.type === TransactionResultType.Success,
     });
-
-    mutate(["tokenAccountData", sessionState.walletPublicKey.toBase58()]).catch(
-      (error: unknown) => {
-        // eslint-disable-next-line no-console
-        console.error(error);
-      },
-    );
 
     return result;
   }, [sessionState, appendTransaction, amount, mint]);

--- a/apps/sessions-demo/src/components/Home/use-trade.ts
+++ b/apps/sessions-demo/src/components/Home/use-trade.ts
@@ -5,7 +5,6 @@ import type { EstablishedSessionState } from "@fogo/sessions-sdk-react";
 import { getAssociatedTokenAddressSync, getMint } from "@solana/spl-token";
 import { PublicKey } from "@solana/web3.js";
 import { useCallback } from "react";
-import { mutate } from "swr";
 
 import type { Transaction } from "./use-transaction-log";
 import { useAsync } from "../../hooks/use-async";
@@ -43,13 +42,6 @@ export const useTrade = (
       signature: result.signature,
       success: result.type === TransactionResultType.Success,
     });
-
-    mutate(["tokenAccountData", sessionState.walletPublicKey.toBase58()]).catch(
-      (error: unknown) => {
-        // eslint-disable-next-line no-console
-        console.error(error);
-      },
-    );
 
     return result;
   }, [sessionState, appendTransaction, amount, mint]);

--- a/packages/sessions-sdk-react/package.json
+++ b/packages/sessions-sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fogo/sessions-sdk-react",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "description": "React components and hooks for integrating with Fogo sessions",
   "keywords": [
@@ -29,15 +29,15 @@
   },
   "scripts": {
     "build:cjs": "tsc --project tsconfig.build.json --verbatimModuleSyntax false --module commonjs --outDir ./dist/cjs && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
-    "build:css:cjs": "sass --no-source-map src:dist/cjs",
-    "build:css:esm": "sass --no-source-map src:dist/esm",
+    "build:css:cjs": "sass --pkg-importer node --no-source-map src:dist/cjs",
+    "build:css:esm": "sass --pkg-importer node --no-source-map src:dist/esm",
     "build:esm": "tsc --project tsconfig.build.json --outDir ./dist/esm && echo '{\"type\":\"module\"}' > dist/esm/package.json",
     "build:package-json": "transform-package-json ./package.json dist/package.json",
     "fix:format": "prettier --write .",
     "fix:lint:eslint": "eslint --fix .",
     "fix:lint:stylelint": "stylelint --fix 'src/**/*.scss'",
     "start:dev:tsc": "tsc --project tsconfig.build.json --outDir ./dist/esm --watch",
-    "start:dev:sass": "sass --watch src:dist/esm",
+    "start:dev:sass": "sass --pkg-importer node --watch src:dist/esm",
     "test:format": "run-jest --colors --selectProjects format",
     "test:integration": "run-jest --colors --selectProjects integration",
     "test:lint:eslint": "run-jest --colors --selectProjects lint",
@@ -64,6 +64,7 @@
     "@solana/web3.js": "catalog:",
     "clsx": "catalog:",
     "idb": "catalog:",
+    "modern-normalize": "catalog:",
     "react-aria-components": "catalog:",
     "swr": "catalog:",
     "zod": "catalog:"

--- a/packages/sessions-sdk-react/src/session-button.module.scss
+++ b/packages/sessions-sdk-react/src/session-button.module.scss
@@ -5,6 +5,7 @@
   height: theme.spacing(10);
 
   @include theme.button("mainButton");
+  @include theme.reset;
 
   .fogoWordmark {
     height: 1.4em;
@@ -27,6 +28,8 @@
   transition:
     transform 200ms,
     opacity 200ms;
+
+  @include theme.reset;
 
   .overlayArrow {
     display: block;
@@ -101,6 +104,7 @@
           flex-flow: column nowrap;
           gap: theme.spacing(2);
           padding: theme.spacing(2);
+          margin: 0;
 
           .token {
             display: grid;
@@ -150,6 +154,13 @@
       }
 
       .logoutButton {
+        border: none;
+        background: transparent;
+        cursor: pointer;
+        padding: theme.spacing(1) theme.spacing(4);
+        position: relative;
+        margin-right: -#{theme.spacing(4)};
+
         &[data-hovered] {
           text-decoration: underline;
         }

--- a/packages/sessions-sdk-react/src/session-limits.module.scss
+++ b/packages/sessions-sdk-react/src/session-limits.module.scss
@@ -10,6 +10,9 @@
     flex-flow: column nowrap;
     gap: theme.spacing(2);
     align-items: center;
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
 
     .token {
       display: grid;

--- a/packages/sessions-sdk-react/src/session-provider.module.scss
+++ b/packages/sessions-sdk-react/src/session-provider.module.scss
@@ -11,6 +11,8 @@
   display: grid;
   place-content: center;
 
+  @include theme.reset;
+
   &[data-entering] {
     animation: modal-fade 200ms;
   }

--- a/packages/sessions-sdk-react/src/theme.scss
+++ b/packages/sessions-sdk-react/src/theme.scss
@@ -1,4 +1,6 @@
 @use "sass:map";
+@use "sass:meta";
+@import "https://fonts.googleapis.com/css2?family=Funnel+Display:wght@300..800&display=swap";
 
 @function map-get-strict($map, $key...) {
   @if map.has-key($map, $key...) {
@@ -444,6 +446,16 @@ $color: (
   @return map-get-strict($color, $color-path...);
 }
 
+@mixin reset {
+  @include meta.load-css("pkg:modern-normalize");
+
+  & {
+    font-family: "Funnel Display", sans-serif;
+    font-optical-sizing: auto;
+    font-style: normal;
+  }
+}
+
 @mixin sr-only {
   position: absolute;
   width: 1px;
@@ -481,6 +493,7 @@ $color: (
     color linear 50ms;
   position: relative;
   padding: spacing(1) spacing(10);
+  cursor: pointer;
 
   &::before {
     position: absolute;

--- a/packages/sessions-sdk-react/src/use-token-account-data.ts
+++ b/packages/sessions-sdk-react/src/use-token-account-data.ts
@@ -18,11 +18,16 @@ export const useTokenAccountData = (sessionState: EstablishedSessionState) => {
   );
 
   return useData(
-    ["tokenAccountData", sessionState.walletPublicKey.toBase58()],
+    getCacheKey(sessionState.walletPublicKey),
     getTokenAccountData,
     {},
   );
 };
+
+export const getCacheKey = (walletPublicKey: PublicKey) => [
+  "tokenAccountData",
+  walletPublicKey.toBase58(),
+];
 
 const getTokenAccounts = async (
   connection: Connection,

--- a/packages/sessions-sdk/package.json
+++ b/packages/sessions-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fogo/sessions-sdk",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "description": "A set of utilities for integrating with Fogo sessions",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -609,6 +609,9 @@ importers:
       idb:
         specifier: 'catalog:'
         version: 8.0.3
+      modern-normalize:
+        specifier: 'catalog:'
+        version: 3.0.1
       react-aria-components:
         specifier: 'catalog:'
         version: 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)


### PR DESCRIPTION
This commit attempts to add some reset & font css to ensure that the widget gets a consistent style, regardless of the context of the surrounding app.  It won't be perfectly isolated, but it should do a fairly good job in most situations.

This commit also adds some code to bust the token account data cache after transactions are sent successfully.