### PR TITLE
feat: allow sessions to be created with no permissions

### DIFF
--- a/packages/sessions-sdk-react/package.json
+++ b/packages/sessions-sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fogo/sessions-sdk-react",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "description": "React components and hooks for integrating with Fogo sessions",
   "keywords": [

--- a/packages/sessions-sdk-ts/package.json
+++ b/packages/sessions-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fogo/sessions-sdk",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "description": "A set of utilities for integrating with Fogo sessions",
   "keywords": [

--- a/packages/sessions-sdk-ts/src/index.ts
+++ b/packages/sessions-sdk-ts/src/index.ts
@@ -211,15 +211,17 @@ const serializeKV = (data: Record<string, string>) =>
     .join("\n");
 
 const serializeTokenList = (tokens: TokenInfo[]) =>
-  tokens
-    .values()
-    .filter(({ amount }) => amount > 0n)
-    .map(
-      ({ symbolOrMint, amount, decimals }) =>
-        `\n-${symbolOrMint.type === SymbolOrMintType.Symbol ? symbolOrMint.symbol : symbolOrMint.mint.toBase58()}: ${amountToString(amount, decimals)}`,
-    )
-    .toArray()
-    .join("");
+  tokens.length === 0
+    ? "\n"
+    : tokens
+        .values()
+        .filter(({ amount }) => amount > 0n)
+        .map(
+          ({ symbolOrMint, amount, decimals }) =>
+            `\n-${symbolOrMint.type === SymbolOrMintType.Symbol ? symbolOrMint.symbol : symbolOrMint.mint.toBase58()}: ${amountToString(amount, decimals)}`,
+        )
+        .toArray()
+        .join("");
 
 const amountToString = (amount: bigint, decimals: number): string => {
   const asStr = amount.toString();


### PR DESCRIPTION
This will be necessary for apps that only read account metadata but does not perform transactions, for instance, if we have a faucet app, or an account portfolio app, etc.

In these cases, the app does not request access to any tokens, and the session init flow skips the limit setting popup