### PR TITLE
fix: fix type-only import

### DIFF
--- a/packages/sessions-sdk-ts/package.json
+++ b/packages/sessions-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fogo/sessions-sdk",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "description": "A set of utilities for integrating with Fogo sessions",
   "keywords": [

--- a/packages/sessions-sdk-ts/src/index.ts
+++ b/packages/sessions-sdk-ts/src/index.ts
@@ -1,4 +1,5 @@
-import { AnchorProvider, Wallet } from "@coral-xyz/anchor";
+import type { Wallet } from "@coral-xyz/anchor";
+import { AnchorProvider } from "@coral-xyz/anchor";
 import { DomainRegistryIdl, SessionManagerProgram } from "@fogo/sessions-idls";
 import {
   findMetadataPda,
@@ -13,12 +14,8 @@ import {
   getAssociatedTokenAddressSync,
   getMint,
 } from "@solana/spl-token";
-import type { TransactionError } from "@solana/web3.js";
-import {
-  Ed25519Program,
-  PublicKey,
-  TransactionInstruction,
-} from "@solana/web3.js";
+import type { TransactionInstruction, TransactionError } from "@solana/web3.js";
+import { Ed25519Program, PublicKey } from "@solana/web3.js";
 
 import type { SessionAdapter, TransactionResult } from "./adapter.js";
 import { TransactionResultType } from "./adapter.js";


### PR DESCRIPTION
We only use `Wallet` as a type, usually the tsconfig `verbatimModuleSyntax` option (which we have set) catches these and ensures we add a type import, but it doesn't seem to work when importing es6 classes.

It's important to mark this as a type-only import, because it's not available in some environments, such as when bundled for the browser