### PR TITLE
fix: ensure workspace dependency versions float

### DIFF
--- a/packages/sessions-sdk-react/package.json
+++ b/packages/sessions-sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fogo/sessions-sdk-react",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "description": "React components and hooks for integrating with Fogo sessions",
   "keywords": [
@@ -50,9 +50,9 @@
   },
   "dependencies": {
     "@coral-xyz/anchor": "catalog:",
-    "@fogo/sessions-idls": "workspace:*",
-    "@fogo/sessions-sdk": "workspace:*",
-    "@fogo/sessions-sdk-web": "workspace:*",
+    "@fogo/sessions-idls": "workspace:^",
+    "@fogo/sessions-sdk": "workspace:^",
+    "@fogo/sessions-sdk-web": "workspace:^",
     "@metaplex-foundation/mpl-token-metadata": "catalog:",
     "@metaplex-foundation/umi": "catalog:",
     "@metaplex-foundation/umi-bundle-defaults": "catalog:",

--- a/packages/sessions-sdk-ts/package.json
+++ b/packages/sessions-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fogo/sessions-sdk",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "description": "A set of utilities for integrating with Fogo sessions",
   "keywords": [
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "@coral-xyz/anchor": "catalog:",
-    "@fogo/sessions-idls": "workspace:*",
+    "@fogo/sessions-idls": "workspace:^",
     "@metaplex-foundation/mpl-token-metadata": "catalog:",
     "@metaplex-foundation/umi": "catalog:",
     "@metaplex-foundation/umi-bundle-defaults": "catalog:",

--- a/packages/sessions-sdk-web/package.json
+++ b/packages/sessions-sdk-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fogo/sessions-sdk-web",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "description": "A set of framework-agnostic utilities for integrating with Fogo sessions on web",
   "keywords": [
@@ -36,7 +36,7 @@
     "test:types": "tsc"
   },
   "dependencies": {
-    "@fogo/sessions-sdk": "workspace:*",
+    "@fogo/sessions-sdk": "workspace:^",
     "@solana/web3.js": "catalog:",
     "idb": "catalog:"
   },
@@ -46,7 +46,6 @@
     "@cprussin/prettier-config": "catalog:",
     "@cprussin/transform-package-json": "catalog:",
     "@cprussin/tsconfig": "catalog:",
-    "@fogo/sessions-sdk": "workspace:*",
     "@types/jest": "catalog:",
     "@types/node": "catalog:",
     "eslint": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -495,13 +495,13 @@ importers:
         specifier: 'catalog:'
         version: 0.31.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@fogo/sessions-idls':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../sessions-idls
       '@fogo/sessions-sdk':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../sessions-sdk-ts
       '@fogo/sessions-sdk-web':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../sessions-sdk-web
       '@metaplex-foundation/mpl-token-metadata':
         specifier: 'catalog:'
@@ -631,7 +631,7 @@ importers:
         specifier: 'catalog:'
         version: 0.31.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@fogo/sessions-idls':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../sessions-idls
       '@metaplex-foundation/mpl-token-metadata':
         specifier: 'catalog:'
@@ -707,7 +707,7 @@ importers:
   packages/sessions-sdk-web:
     dependencies:
       '@fogo/sessions-sdk':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../sessions-sdk-ts
       '@solana/web3.js':
         specifier: 'catalog:'


### PR DESCRIPTION
This ensures that workspace dependencies get transformed to version ranges rather than using exact versions.  This is important because it ensures we can version underlying packages (e.g. `@fogo/sessions-sdk`) without also publishing all packages that depend on the underlying packages