### PR TITLE
chore: improve sdk and in-code docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,7 +776,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fogo-sessions-sdk"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "borsh 0.10.4",
  "solana-program",

--- a/apps/sessions-demo/src/components/Home/use-trade.ts
+++ b/apps/sessions-demo/src/components/Home/use-trade.ts
@@ -29,7 +29,7 @@ export const useTrade = (
       ).methods
         .exampleTransfer(new BN(amount * Math.pow(10, decimals)))
         .accountsPartial({
-          sessionKey: sessionState.sessionPublicKey,
+          signerOrSession: sessionState.sessionPublicKey,
           sink: sinkAta,
           userTokenAccount,
           mint,

--- a/packages/sessions-sdk-rs/Cargo.toml
+++ b/packages/sessions-sdk-rs/Cargo.toml
@@ -3,7 +3,7 @@ name = "fogo-sessions-sdk"
 description = "A set of utilities for SVM on-chain programs integrating with Fogo sessions"
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.0"
+version = "0.3.1"
 
 [lib]
 crate-type = ["rlib"]

--- a/packages/sessions-sdk-rs/src/session/mod.rs
+++ b/packages/sessions-sdk-rs/src/session/mod.rs
@@ -14,11 +14,19 @@ pub mod token_program;
 pub const SESSION_MANAGER_ID: Pubkey =
     solana_program::pubkey!("SesswvJ7puvAgpyqp7N8HnjNnvpnS8447tKNF3sPgbC");
 
+/// The current major version of the `Session` structure
 pub const MAJOR: u8 = 0;
+/// The current minor version of the `Session` structure
 pub const MINOR: u8 = 1;
 
 type UnixTimestamp = i64;
 
+/// Returns true if `info` is a session account
+pub fn is_session(info: &AccountInfo) -> bool {
+    info.owner == &SESSION_MANAGER_ID
+}
+
+/// The on-chain representation of a session. Sessions are represented on-chain as accounts owned by the session manager program, containing a `Session` structure.
 #[derive(Debug, Clone, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct Session {
     pub discriminator: [u8; 8],
@@ -39,7 +47,7 @@ pub struct SessionInfo {
     pub expiration: UnixTimestamp,
     /// Programs the session key is allowed to interact with as a (program_id, signer_pda) pair. We store the signer PDAs so we don't have to recalculate them
     pub authorized_programs: AuthorizedPrograms,
-    /// Tokens the session key is allowed to interact with. If `Specific`, the spend limits are stored in each individual token account in the usual delegated_amount field.
+    /// Tokens the session key is allowed to interact with. If `Specific`, the spend limits are stored in each individual token account in the usual `delegated_amount` field.
     pub authorized_tokens: AuthorizedTokens,
     /// Extra (key, value)'s provided by the user, they can be used to store extra arbitrary information about the session
     pub extra: Extra,
@@ -102,7 +110,8 @@ impl From<HashMap<String, String>> for Extra {
 impl Session {
     pub const DISCRIMINATOR: [u8; 8] = [243, 81, 72, 115, 214, 188, 72, 144];
 
-    pub fn extract_user_from_session(
+    /// Extracts the user public key from a signer or session account. If the account is a session, it extracts the user from the session data and also checks that the session is live and the session is allowed to interact with `program_id` on behalf of the user. Otherwise, it just returns the public key of the signer.
+    pub fn extract_user_from_signer_or_session(
         info: &AccountInfo,
         program_id: &Pubkey,
     ) -> Result<Pubkey, SessionError> {
@@ -118,6 +127,7 @@ impl Session {
         }
     }
 
+    /// Tries to deserialize a session account. This should only be used after checking that the account is owned by the session manager program.
     pub fn try_deserialize(data: &mut &[u8]) -> Result<Self, SessionError> {
         let result = Session::deserialize(data).map_err(|_| SessionError::InvalidAccountData)?;
         if result.discriminator != Self::DISCRIMINATOR {
@@ -164,5 +174,10 @@ impl Session {
         self.check_is_live()?;
         self.check_authorized_program(program_id)?;
         Ok(self.session_info.user)
+    }
+
+    /// Returns the value of one of the session's extra fields with the given key, if it exists
+    pub fn get_extra(&self, key: &str) -> Option<&str> {
+        self.session_info.extra.get(key)
     }
 }

--- a/packages/sessions-sdk-rs/src/session/mod.rs
+++ b/packages/sessions-sdk-rs/src/session/mod.rs
@@ -110,7 +110,7 @@ impl From<HashMap<String, String>> for Extra {
 impl Session {
     pub const DISCRIMINATOR: [u8; 8] = [243, 81, 72, 115, 214, 188, 72, 144];
 
-    /// Extracts the user public key from a signer or session account. If the account is a session, it extracts the user from the session data and also checks that the session is live and the session is allowed to interact with `program_id` on behalf of the user. Otherwise, it just returns the public key of the signer.
+    /// Extracts the user public key from a signer or a session account. If the account is a session, it extracts the user from the session data and also checks that the session is live and the session is allowed to interact with `program_id` on behalf of the user. Otherwise, it just returns the public key of the signer.
     pub fn extract_user_from_signer_or_session(
         info: &AccountInfo,
         program_id: &Pubkey,

--- a/packages/sessions-sdk-rs/src/session/mod.rs
+++ b/packages/sessions-sdk-rs/src/session/mod.rs
@@ -21,7 +21,7 @@ pub const MINOR: u8 = 1;
 
 type UnixTimestamp = i64;
 
-/// Returns true if `info` is a session account
+/// Returns whether `info` is a session account
 pub fn is_session(info: &AccountInfo) -> bool {
     info.owner == &SESSION_MANAGER_ID
 }

--- a/packages/sessions-sdk-rs/src/token/instruction.rs
+++ b/packages/sessions-sdk-rs/src/token/instruction.rs
@@ -16,7 +16,7 @@ fn check_program_account(spl_token_program_id: &Pubkey) -> Result<(), ProgramErr
 
 /// This function is meant to replace `spl_token::instruction::transfer` in the context of sessions. 
 /// In-session token transfers are different from regular transfers in that they not only require the session key to sign as the authority, but also require an additional signer.
-/// This additional signer is the `program_signer` and allows the token program to verify that the transfer is happening within an authorized program.
+/// This additional signer is the `program_signer` and allows the token program to verify that the transfer is happening within an authorized program. It is the PDA of the authorized program that will call the instruction via CPI with seed `PROGRAM_SIGNER_SEED`.
 /// This function has also been designed to allow non-sessions transfers by setting the `program_signer` to `None`.
 pub fn transfer(
     token_program_id: &Pubkey,
@@ -51,7 +51,7 @@ pub fn transfer(
 
 /// This function is meant to replace `spl_token::instruction::transfer_checked` in the context of sessions. 
 /// In-session token transfers are different from regular transfers in that they not only require the session key to sign as the authority, but also require an additional signer.
-/// This additional signer is the `program_signer` and allows the token program to verify that the transfer is happening within an authorized program.
+/// This additional signer is the `program_signer` and allows the token program to verify that the transfer is happening within an authorized program. It is the PDA of the authorized program that will call the instruction via CPI with seed `PROGRAM_SIGNER_SEED`.
 /// This function has also been designed to allow non-sessions transfers by setting the `program_signer` to `None`.
 #[allow(clippy::too_many_arguments)]
 pub fn transfer_checked(

--- a/packages/sessions-sdk-rs/src/token/instruction.rs
+++ b/packages/sessions-sdk-rs/src/token/instruction.rs
@@ -14,22 +14,29 @@ fn check_program_account(spl_token_program_id: &Pubkey) -> Result<(), ProgramErr
     Ok(())
 }
 
+/// This function is meant to replace `spl_token::instruction::transfer` in the context of sessions. 
+/// In-session transfers are different from regular transfers in that they not only require the session key to sign as the authority, but also require an additional signer.
+/// This additional signer is the `program_signer` and allows the token program to verify that the transfer is happening within an authorized program.
+/// This function has also been designed to allow non-sessions transfers by setting the `program_signer` to `None`.
 pub fn transfer(
     token_program_id: &Pubkey,
     source_pubkey: &Pubkey,
     destination_pubkey: &Pubkey,
     session_key: &Pubkey,
-    program_signer: &Pubkey,
+    program_signer: Option<&Pubkey>,
     amount: u64,
 ) -> Result<Instruction, ProgramError> {
     check_program_account(token_program_id)?;
 
-    let accounts = vec![
+    let mut accounts = vec![
         AccountMeta::new(*source_pubkey, false),
         AccountMeta::new(*destination_pubkey, false),
         AccountMeta::new_readonly(*session_key, true),
-        AccountMeta::new_readonly(*program_signer, true),
     ];
+
+    if let Some(program_signer) = program_signer {
+        accounts.push(AccountMeta::new_readonly(*program_signer, true));
+    }
 
     let mut data = Vec::with_capacity(8);
     data.push(3);
@@ -42,6 +49,10 @@ pub fn transfer(
     })
 }
 
+/// This function is meant to replace `spl_token::instruction::transfer_checked` in the context of sessions. 
+/// In-session transfers are different from regular transfers in that they not only require the session key to sign as the authority, but also require an additional signer.
+/// This additional signer is the `program_signer` and allows the token program to verify that the transfer is happening within an authorized program.
+/// This function has also been designed to allow non-sessions transfers by setting the `program_signer` to `None`.
 #[allow(clippy::too_many_arguments)]
 pub fn transfer_checked(
     token_program_id: &Pubkey,
@@ -49,19 +60,22 @@ pub fn transfer_checked(
     mint_pubkey: &Pubkey,
     destination_pubkey: &Pubkey,
     session_key: &Pubkey,
-    program_signer: &Pubkey,
+    program_signer: Option<&Pubkey>,
     amount: u64,
     decimals: u8,
 ) -> Result<Instruction, ProgramError> {
     check_program_account(token_program_id)?;
 
-    let accounts = vec![
+    let mut accounts = vec![
         AccountMeta::new(*source_pubkey, false),
         AccountMeta::new_readonly(*mint_pubkey, false),
         AccountMeta::new(*destination_pubkey, false),
         AccountMeta::new_readonly(*session_key, true),
-        AccountMeta::new_readonly(*program_signer, true),
     ];
+
+    if let Some(program_signer) = program_signer {
+        accounts.push(AccountMeta::new_readonly(*program_signer, true));
+    }
 
     let mut data = Vec::with_capacity(8);
     data.push(12);

--- a/packages/sessions-sdk-rs/src/token/instruction.rs
+++ b/packages/sessions-sdk-rs/src/token/instruction.rs
@@ -15,7 +15,7 @@ fn check_program_account(spl_token_program_id: &Pubkey) -> Result<(), ProgramErr
 }
 
 /// This function is meant to replace `spl_token::instruction::transfer` in the context of sessions. 
-/// In-session transfers are different from regular transfers in that they not only require the session key to sign as the authority, but also require an additional signer.
+/// In-session tokentransfers are different from regular transfers in that they not only require the session key to sign as the authority, but also require an additional signer.
 /// This additional signer is the `program_signer` and allows the token program to verify that the transfer is happening within an authorized program.
 /// This function has also been designed to allow non-sessions transfers by setting the `program_signer` to `None`.
 pub fn transfer(
@@ -50,7 +50,7 @@ pub fn transfer(
 }
 
 /// This function is meant to replace `spl_token::instruction::transfer_checked` in the context of sessions. 
-/// In-session transfers are different from regular transfers in that they not only require the session key to sign as the authority, but also require an additional signer.
+/// In-session token transfers are different from regular transfers in that they not only require the session key to sign as the authority, but also require an additional signer.
 /// This additional signer is the `program_signer` and allows the token program to verify that the transfer is happening within an authorized program.
 /// This function has also been designed to allow non-sessions transfers by setting the `program_signer` to `None`.
 #[allow(clippy::too_many_arguments)]

--- a/packages/sessions-sdk-rs/src/token/instruction.rs
+++ b/packages/sessions-sdk-rs/src/token/instruction.rs
@@ -14,7 +14,7 @@ fn check_program_account(spl_token_program_id: &Pubkey) -> Result<(), ProgramErr
     Ok(())
 }
 
-/// This function is meant to replace `spl_token::instruction::transfer` in the context of sessions. 
+/// This function is meant to replace `spl_token::instruction::transfer` in the context of sessions.
 /// In-session token transfers are different from regular transfers in that they not only require the session key to sign as the authority, but also require an additional signer.
 /// This additional signer is the `program_signer` and allows the token program to verify that the transfer is happening within an authorized program. It is the PDA of the authorized program that will call the instruction via CPI with seed `PROGRAM_SIGNER_SEED`.
 /// This function has also been designed to allow non-sessions transfers by setting the `program_signer` to `None`.
@@ -49,7 +49,7 @@ pub fn transfer(
     })
 }
 
-/// This function is meant to replace `spl_token::instruction::transfer_checked` in the context of sessions. 
+/// This function is meant to replace `spl_token::instruction::transfer_checked` in the context of sessions.
 /// In-session token transfers are different from regular transfers in that they not only require the session key to sign as the authority, but also require an additional signer.
 /// This additional signer is the `program_signer` and allows the token program to verify that the transfer is happening within an authorized program. It is the PDA of the authorized program that will call the instruction via CPI with seed `PROGRAM_SIGNER_SEED`.
 /// This function has also been designed to allow non-sessions transfers by setting the `program_signer` to `None`.

--- a/packages/sessions-sdk-rs/src/token/instruction.rs
+++ b/packages/sessions-sdk-rs/src/token/instruction.rs
@@ -22,7 +22,7 @@ pub fn transfer(
     token_program_id: &Pubkey,
     source_pubkey: &Pubkey,
     destination_pubkey: &Pubkey,
-    session_key: &Pubkey,
+    authority_pubkey: &Pubkey,
     program_signer: Option<&Pubkey>,
     amount: u64,
 ) -> Result<Instruction, ProgramError> {
@@ -31,7 +31,7 @@ pub fn transfer(
     let mut accounts = vec![
         AccountMeta::new(*source_pubkey, false),
         AccountMeta::new(*destination_pubkey, false),
-        AccountMeta::new_readonly(*session_key, true),
+        AccountMeta::new_readonly(*authority_pubkey, true),
     ];
 
     if let Some(program_signer) = program_signer {
@@ -59,7 +59,7 @@ pub fn transfer_checked(
     source_pubkey: &Pubkey,
     mint_pubkey: &Pubkey,
     destination_pubkey: &Pubkey,
-    session_key: &Pubkey,
+    authority_pubkey: &Pubkey,
     program_signer: Option<&Pubkey>,
     amount: u64,
     decimals: u8,
@@ -70,7 +70,7 @@ pub fn transfer_checked(
         AccountMeta::new(*source_pubkey, false),
         AccountMeta::new_readonly(*mint_pubkey, false),
         AccountMeta::new(*destination_pubkey, false),
-        AccountMeta::new_readonly(*session_key, true),
+        AccountMeta::new_readonly(*authority_pubkey, true),
     ];
 
     if let Some(program_signer) = program_signer {

--- a/packages/sessions-sdk-rs/src/token/instruction.rs
+++ b/packages/sessions-sdk-rs/src/token/instruction.rs
@@ -15,7 +15,7 @@ fn check_program_account(spl_token_program_id: &Pubkey) -> Result<(), ProgramErr
 }
 
 /// This function is meant to replace `spl_token::instruction::transfer` in the context of sessions. 
-/// In-session tokentransfers are different from regular transfers in that they not only require the session key to sign as the authority, but also require an additional signer.
+/// In-session token transfers are different from regular transfers in that they not only require the session key to sign as the authority, but also require an additional signer.
 /// This additional signer is the `program_signer` and allows the token program to verify that the transfer is happening within an authorized program.
 /// This function has also been designed to allow non-sessions transfers by setting the `program_signer` to `None`.
 pub fn transfer(

--- a/packages/sessions-sdk-rs/src/token/mod.rs
+++ b/packages/sessions-sdk-rs/src/token/mod.rs
@@ -1,5 +1,5 @@
 pub mod instruction;
 
-/// This seed is used to derive a program's signer PDA in the context of session's token transfers.
+/// This seed is used to derive a program's signer PDA in the context of sessions.
 /// This PDA is required to sign in-session token transfers. This allows the token program to verify that the transfer is happening within an authorized program.
 pub const PROGRAM_SIGNER_SEED: &[u8] = b"fogo_session_program_signer";

--- a/packages/sessions-sdk-rs/src/token/mod.rs
+++ b/packages/sessions-sdk-rs/src/token/mod.rs
@@ -1,5 +1,5 @@
 pub mod instruction;
 
 /// This seed is used to derive a program's signer PDA in the context of session's token transfers.
-/// This PDA is required to sign in-session token transfers.
+/// This PDA is required to sign in-session token transfers. This allows the token program to verify that the transfer is happening within an authorized program.
 pub const PROGRAM_SIGNER_SEED: &[u8] = b"fogo_session_program_signer";

--- a/packages/sessions-sdk-rs/src/token/mod.rs
+++ b/packages/sessions-sdk-rs/src/token/mod.rs
@@ -1,3 +1,5 @@
 pub mod instruction;
 
+/// This seed is used to derive a program's signer PDA in the context of session's token transfers.
+/// This PDA is required to sign in-session token transfers.
 pub const PROGRAM_SIGNER_SEED: &[u8] = b"fogo_session_program_signer";

--- a/programs/example/src/lib.rs
+++ b/programs/example/src/lib.rs
@@ -8,7 +8,6 @@ use fogo_sessions_sdk::session::is_session;
 use fogo_sessions_sdk::token::instruction::transfer_checked;
 use fogo_sessions_sdk::{session::Session, token::PROGRAM_SIGNER_SEED};
 use anchor_spl::associated_token::get_associated_token_address;
-use spl_token::instruction::transfer;
 
 declare_id!("Examtz9qAwhxcADNFodNA2QpxK7SM9bCHyiaUvWvFBM3");
 

--- a/programs/example/src/lib.rs
+++ b/programs/example/src/lib.rs
@@ -18,7 +18,7 @@ pub mod example {
         // Extract the user public key from the signing account
         let user = Session::extract_user_from_signer_or_session(&ctx.accounts.signer_or_session, &crate::ID).map_err(|_| ProgramError::InvalidAccountData)?;
 
-        // Check that user_token_account is the user's token associated account
+        // Check that user_token_account is the user's associated token account
         require_eq!(get_associated_token_address(&user, &ctx.accounts.mint.key()), ctx.accounts.user_token_account.key());
 
         let instruction = transfer_checked(
@@ -59,7 +59,7 @@ pub struct ExampleTransfer<'info> {
     /// This is either the user or a session representing the user
     pub signer_or_session: Signer<'info>,
     /// If within a session, this account is needed to sign token transfers in addition to the session key.
-    /// CHECK: this is just a signer for token program CPIs
+    /// CHECK: this is just a PDA signer for token program CPIs
     #[account(seeds = [PROGRAM_SIGNER_SEED], bump)]
     pub program_signer: Option<AccountInfo<'info>>,
     #[account(mut, token::mint = mint)]

--- a/programs/example/src/lib.rs
+++ b/programs/example/src/lib.rs
@@ -1,10 +1,14 @@
 #![allow(unexpected_cfgs)] // warning: unexpected `cfg` condition value: `anchor-debug`
 
 use anchor_lang::prelude::*;
+use anchor_lang::solana_program::program::invoke;
 use anchor_lang::solana_program::program::invoke_signed;
 use anchor_spl::token::{Mint, Token, TokenAccount};
+use fogo_sessions_sdk::session::is_session;
 use fogo_sessions_sdk::token::instruction::transfer_checked;
 use fogo_sessions_sdk::{session::Session, token::PROGRAM_SIGNER_SEED};
+use anchor_spl::associated_token::get_associated_token_address;
+use spl_token::instruction::transfer;
 
 declare_id!("Examtz9qAwhxcADNFodNA2QpxK7SM9bCHyiaUvWvFBM3");
 
@@ -12,37 +16,57 @@ declare_id!("Examtz9qAwhxcADNFodNA2QpxK7SM9bCHyiaUvWvFBM3");
 pub mod example {
     use super::*;
     pub fn example_transfer(ctx: Context<ExampleTransfer>, amount: u64) -> Result<()> {
+        // Extract the user public key from the signing account
+        let user = Session::extract_user_from_signer_or_session(&ctx.accounts.signer_or_session, &crate::ID).map_err(|_| ProgramError::InvalidAccountData)?;
+
+        // Check that user_token_account is the user's token associated account
+        require_eq!(get_associated_token_address(&user, &ctx.accounts.mint.key()), ctx.accounts.user_token_account.key());
+
         let instruction = transfer_checked(
             ctx.accounts.token_program.key,
             &ctx.accounts.user_token_account.key(),
             &ctx.accounts.mint.key(),
             &ctx.accounts.sink.key(),
-            &ctx.accounts.session_key.key(),
-            &ctx.accounts.program_signer.key(),
+            &ctx.accounts.signer_or_session.key(),
+            ctx.accounts
+                .program_signer
+                .as_ref()
+                .map(|account_info| account_info.key()).as_ref(),
             amount,
             ctx.accounts.mint.decimals,
         )?;
-        invoke_signed(
-            &instruction,
-            &ctx.accounts.to_account_infos(),
-            &[&[PROGRAM_SIGNER_SEED, &[ctx.bumps.program_signer]]],
-        )?;
+
+        let is_session = is_session(&ctx.accounts.signer_or_session);
+
+        match (is_session, ctx.accounts.program_signer.as_ref()) {
+            (_, Some(_)) => {
+                invoke_signed(&instruction, &ctx.accounts.to_account_infos(), &[&[PROGRAM_SIGNER_SEED, &[ctx.bumps.program_signer.expect("program_signer is some")]]])?;
+            }
+            (false, None) => {
+                // If it's not a session, it's okay to not provide the program signer
+                invoke(&instruction, &ctx.accounts.to_account_infos())?;
+            }
+            (true, None) => {
+                // Program signer is required if it's a session
+                return Err(ProgramError::NotEnoughAccountKeys.into());
+            }
+        }
         Ok(())
     }
 }
 
 #[derive(Accounts)]
 pub struct ExampleTransfer<'info> {
-    /// CHECK: we check this using `Session::extract_user_from_session`
-    #[account(signer)]
-    pub session_key: AccountInfo<'info>,
+    /// This is either the user or a session representing the user
+    pub signer_or_session: Signer<'info>,
+    /// If within a session, this account is needed to sign token transfers in addition to the session key.
     /// CHECK: this is just a signer for token program CPIs
     #[account(seeds = [PROGRAM_SIGNER_SEED], bump)]
-    pub program_signer: AccountInfo<'info>,
-    #[account(mut, token::mint = mint, token::authority = Session::extract_user_from_session(&session_key, &crate::ID).map_err(|_| ProgramError::InvalidAccountData)?)]
+    pub program_signer: Option<AccountInfo<'info>>,
+    #[account(mut, token::mint = mint)]
     pub user_token_account: Account<'info, TokenAccount>,
     pub mint: Account<'info, Mint>,
-    #[account(mut)]
+    #[account(mut, token::mint = mint)]
     pub sink: Account<'info, TokenAccount>,
     pub token_program: Program<'info, Token>,
 }


### PR DESCRIPTION
- make it easier for apps to support both session and non-session interactions at the same time
- use associated token accounts in the example as it is more conventional than arbitrary token accounts
- rename some things the flow is clearer

