### PR TITLE
chore: fix avm ci installation

### DIFF
--- a/.github/workflows/turbo-build.yaml
+++ b/.github/workflows/turbo-build.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install anchor cli
         run: |
-          cargo install --git https://github.com/coral-xyz/anchor avm
+          cargo install --git https://github.com/coral-xyz/anchor --tag v0.31.1 --locked avm
           avm install 0.31.1
           avm use 0.31.1
       - uses: actions/setup-node@v4

--- a/.github/workflows/turbo-test.yaml
+++ b/.github/workflows/turbo-test.yaml
@@ -17,7 +17,7 @@ jobs:
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
       - name: Install anchor cli
         run: |
-          cargo install --git https://github.com/coral-xyz/anchor avm
+          cargo install --git https://github.com/coral-xyz/anchor --tag v0.31.1 --locked avm
           avm install 0.31.1
           avm use 0.31.1
       - uses: actions/setup-node@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,5 @@ codegen-units = 1
 
 [workspace.dependencies]
 anchor-lang = "0.31.1"
+
 anchor-spl = "0.31.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,4 @@ codegen-units = 1
 
 [workspace.dependencies]
 anchor-lang = "0.31.1"
-
 anchor-spl = "0.31.1"


### PR DESCRIPTION
- pin to git tag
- use locked dependencies