### PR TITLE
fix: fix log out button text color

### DIFF
--- a/packages/sessions-sdk-react/src/session-button.module.scss
+++ b/packages/sessions-sdk-react/src/session-button.module.scss
@@ -165,6 +165,7 @@
           padding: theme.spacing(1) theme.spacing(4);
           position: relative;
           margin-right: -#{theme.spacing(4)};
+          color: theme.color("panel", "text");
 
           &[data-hovered] {
             text-decoration: underline;


### PR DESCRIPTION
Fix the color of the logout button matching the underlying app scheme, causing the button to be nearly invisible on dark mode apps