### PR TITLE
feat: allow passing partially signed txs to `sendTransaction`

### DIFF
--- a/packages/sessions-sdk-react/src/session-provider.tsx
+++ b/packages/sessions-sdk-react/src/session-provider.tsx
@@ -28,7 +28,7 @@ import {
   LedgerWalletAdapter,
   TorusWalletAdapter,
 } from "@solana/wallet-adapter-wallets";
-import { PublicKey, TransactionInstruction } from "@solana/web3.js";
+import { PublicKey } from "@solana/web3.js";
 import type { ComponentProps, ReactNode } from "react";
 import {
   createContext,
@@ -217,25 +217,26 @@ const useSessionStateContext = ({
         console.error("Failed to store session", error);
         disconnectWallet();
       });
-      const commonStateArgs = {
-        endSession: () => {
-          endSession(session.walletPublicKey);
-        },
-        payer: session.payer,
-        sendTransaction: async (instructions: TransactionInstruction[]) => {
-          const result = await session.sendTransaction(instructions);
-          mutate(getCacheKey(session.walletPublicKey)).catch(
-            (error: unknown) => {
-              // eslint-disable-next-line no-console
-              console.error("Failed to update token account data", error);
-            },
-          );
-          return result;
-        },
-        sessionPublicKey: session.sessionPublicKey,
-        walletPublicKey: session.walletPublicKey,
-        connection: adapter.connection,
-      };
+      const commonStateArgs: Parameters<typeof SessionState.UpdatingLimits>[0] =
+        {
+          endSession: () => {
+            endSession(session.walletPublicKey);
+          },
+          payer: session.payer,
+          sendTransaction: async (instructions) => {
+            const result = await session.sendTransaction(instructions);
+            mutate(getCacheKey(session.walletPublicKey)).catch(
+              (error: unknown) => {
+                // eslint-disable-next-line no-console
+                console.error("Failed to update token account data", error);
+              },
+            );
+            return result;
+          },
+          sessionPublicKey: session.sessionPublicKey,
+          walletPublicKey: session.walletPublicKey,
+          connection: adapter.connection,
+        };
       const setLimits = (limits: Map<PublicKey, bigint>) => {
         setState(SessionState.UpdatingLimits(commonStateArgs));
         replaceSession({

--- a/packages/sessions-sdk-ts/src/index.ts
+++ b/packages/sessions-sdk-ts/src/index.ts
@@ -14,7 +14,7 @@ import {
   getAssociatedTokenAddressSync,
   getMint,
 } from "@solana/spl-token";
-import type { TransactionInstruction, TransactionError } from "@solana/web3.js";
+import type { TransactionError } from "@solana/web3.js";
 import { Ed25519Program, PublicKey } from "@solana/web3.js";
 
 import type { SessionAdapter, TransactionResult } from "./adapter.js";
@@ -323,6 +323,6 @@ export type Session = {
   walletPublicKey: PublicKey;
   payer: PublicKey;
   sendTransaction: (
-    instructions: TransactionInstruction[],
+    instructions: Parameters<SessionAdapter["sendTransaction"]>[1],
   ) => Promise<TransactionResult>;
 };


### PR DESCRIPTION
Some use cases require adding other signers to txns, so expanding this interface to allow it to take a tx and add the session signature allows those cases to work easily.

There are some downsides to passing a tx:

- We can't set the fee payer on the partially signed tx, so users need to ensure the fee payer is set to the paymaster sponsor
- We can't set the message lifetime either
- Finally, we can't add the ALT to the tx to help compress the intent message size

These are all things the user can handle themselves, so I think it's fair to treat this as a low-level API and discourage it unless it's really needed.