### PR TITLE
feat: use fogo.io/api/token-metadata instead of metaplex

### DIFF
--- a/packages/sessions-sdk-react/src/get-metadata.ts
+++ b/packages/sessions-sdk-react/src/get-metadata.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+export const getMetadata = async (mints: string[]) => {
+  const metadataUrl = new URL("https://www.fogo.io/api/token-metadata");
+  for (const mint of mints) {
+    metadataUrl.searchParams.append("mint[]", mint);
+  }
+  const metadataResult = await fetch(metadataUrl);
+  return metadataSchema.parse(await metadataResult.json());
+};
+
+const metadataSchema = z.record(
+  z.string(),
+  z.object({
+    name: z.string(),
+    symbol: z.string(),
+    image: z.string(),
+  }),
+);

--- a/packages/sessions-sdk-react/src/use-token-account-data.ts
+++ b/packages/sessions-sdk-react/src/use-token-account-data.ts
@@ -4,6 +4,7 @@ import { Connection, PublicKey } from "@solana/web3.js";
 import { useCallback } from "react";
 import { z } from "zod";
 
+import { getMetadata } from "./get-metadata.js";
 import type { EstablishedSessionState } from "./session-provider.js";
 import { useData } from "./use-data.js";
 
@@ -49,6 +50,8 @@ const getTokenAccounts = async (
     }),
   );
 
+  const metadata = await getMetadata(accounts.map((account) => account.mint));
+
   return {
     tokensInWallet: accounts
       .filter(({ amountInWallet }) => amountInWallet !== 0n)
@@ -56,6 +59,7 @@ const getTokenAccounts = async (
         mint: new PublicKey(mint),
         amountInWallet,
         decimals,
+        ...metadata[mint],
       })),
     sessionLimits: accounts
       .filter(
@@ -70,6 +74,7 @@ const getTokenAccounts = async (
               mint: new PublicKey(mint),
               sessionLimit: delegateAmount,
               decimals,
+              ...metadata[mint],
             },
       )
       .filter((account) => account !== undefined),


### PR DESCRIPTION
Reading the metaplex accounts is expensive and unnecessary for loading metadata. This PR instead moves to using the new token-metadata endpoint on the fogo website.

Note we still use metaplex when building the intent message, because we have to use metaplex on chain when reading it and it's important the intent message is built and read using the same metadata source.

This PR also ensures that tokens in the token list have a stable sort order, and that tokens that have no metadata are sorted after those that do have metadata