### PR TITLE
fix: allow domain override in all environments

### DIFF
--- a/packages/sessions-sdk-ts/package.json
+++ b/packages/sessions-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fogo/sessions-sdk",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "private": true,
   "description": "A set of utilities for integrating with Fogo sessions",
   "keywords": [

--- a/packages/sessions-sdk-ts/src/adapter.ts
+++ b/packages/sessions-sdk-ts/src/adapter.ts
@@ -243,15 +243,7 @@ const getDomain = (requestedDomain?: string) => {
       return detectedDomain;
     }
   } else {
-    if (
-      detectedDomain === undefined ||
-      detectedDomain === requestedDomain ||
-      process.env.NODE_ENV !== "production" // eslint-disable-line n/no-process-env
-    ) {
-      return requestedDomain;
-    } else {
-      throw new DomainOverrideNotAllowedError();
-    }
+    return requestedDomain;
   }
 };
 
@@ -275,12 +267,5 @@ class DomainRequiredError extends Error {
       "On platforms where the origin cannot be determined, you must pass a domain to create a session.",
     );
     this.name = "DomainRequiredError";
-  }
-}
-
-class DomainOverrideNotAllowedError extends Error {
-  constructor() {
-    super("You cannot create a session for a different domain.");
-    this.name = "DomainOverrideNotAllowedError";
   }
 }


### PR DESCRIPTION
This code is overzealous and prevents legitimate use cases for testing lower environments, and it doesn't add any actual security since this can be easily circumvented by a malicious actor.

The right way to handle this will be to add something to verify that the domain in the intent message matches the origin domain, probably in the paymaster