### PR TITLE
fix: only show wallet popup when first connecting wallet

### DIFF
--- a/apps/sessions-demo/src/components/Home/demo.tsx
+++ b/apps/sessions-demo/src/components/Home/demo.tsx
@@ -137,8 +137,6 @@ const SESSION_STATE_TO_BADGE_CLASSES: Record<SessionStateType, string> = {
     "border-gray-700 bg-gray-100 text-gray-500",
   [SessionStateType.RequestingLimits]:
     "border-blue-700 bg-blue-50 text-blue-600",
-  [SessionStateType.RestoringSession]:
-    "border-blue-700 bg-blue-50 text-blue-600",
   [SessionStateType.SelectingWallet]:
     "border-blue-700 bg-blue-50 text-blue-600",
   [SessionStateType.SettingLimits]: "border-blue-700 bg-blue-50 text-blue-600",
@@ -153,7 +151,6 @@ const SESSION_STATE_TO_DESCRIPTION: Record<SessionStateType, string> = {
   [SessionStateType.Initializing]: "Booting App",
   [SessionStateType.NotEstablished]: "No Session",
   [SessionStateType.RequestingLimits]: "Requesting limits...",
-  [SessionStateType.RestoringSession]: "Restoring stored session...",
   [SessionStateType.SelectingWallet]: "Selecting Solana wallet...",
   [SessionStateType.SettingLimits]: "Setting requested limits...",
   [SessionStateType.UpdatingLimits]: "Updating limits...",

--- a/packages/sessions-sdk-react/src/session-button.tsx
+++ b/packages/sessions-sdk-react/src/session-button.tsx
@@ -3,7 +3,7 @@
 import { CoinsIcon } from "@phosphor-icons/react/dist/ssr/Coins";
 import { PublicKey } from "@solana/web3.js";
 import type { ComponentProps } from "react";
-import { useMemo, useState, useRef, useCallback } from "react";
+import { useMemo, useState, useRef, useCallback, useEffect } from "react";
 import {
   Button,
   Dialog,
@@ -47,7 +47,8 @@ export const SessionButton = ({
   requestedLimits?: Map<PublicKey, bigint> | Record<string, bigint> | undefined;
 }) => {
   const sessionState = useSession();
-  const [sessionPanelOpen, setSessionPanelOpen] = useState(true);
+  const prevSessionState = useRef(sessionState);
+  const [sessionPanelOpen, setSessionPanelOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const handlePress = useCallback(() => {
     if (isEstablished(sessionState)) {
@@ -74,12 +75,24 @@ export const SessionButton = ({
   const isLoading = [
     SessionStateType.Initializing,
     SessionStateType.CheckingStoredSession,
-    SessionStateType.RestoringSession,
     SessionStateType.RequestingLimits,
     SessionStateType.SettingLimits,
     SessionStateType.WalletConnecting,
     SessionStateType.SelectingWallet,
   ].includes(sessionState.type);
+
+  useEffect(() => {
+    if (sessionState.type !== prevSessionState.current.type) {
+      if (
+        isEstablished(sessionState) &&
+        !isEstablished(prevSessionState.current) &&
+        prevSessionState.current.type !== SessionStateType.CheckingStoredSession
+      ) {
+        setSessionPanelOpen(true);
+      }
+      prevSessionState.current = sessionState;
+    }
+  }, [sessionState.type]);
 
   return (
     <>

--- a/packages/sessions-sdk-react/src/session-provider.tsx
+++ b/packages/sessions-sdk-react/src/session-provider.tsx
@@ -474,7 +474,6 @@ const getNextState = (
       }
       case StateType.CheckingStoredSession:
       case StateType.Established:
-      case StateType.RestoringSession:
       case StateType.RequestingLimits:
       case StateType.SettingLimits:
       case StateType.UpdatingLimits: {
@@ -495,7 +494,6 @@ const getNextState = (
         case StateType.NotEstablished:
         case StateType.WalletConnecting:
         case StateType.SelectingWallet:
-        case StateType.RestoringSession:
         case StateType.RequestingLimits:
         case StateType.UpdatingLimits: {
           return SessionState.CheckingStoredSession(
@@ -522,7 +520,6 @@ const getNextState = (
       case StateType.CheckingStoredSession:
       case StateType.Established:
       case StateType.Initializing:
-      case StateType.RestoringSession:
       case StateType.RequestingLimits:
       case StateType.SettingLimits:
       case StateType.UpdatingLimits:
@@ -554,7 +551,6 @@ export enum StateType {
   SelectingWallet,
   WalletConnecting,
   CheckingStoredSession,
-  RestoringSession,
   RequestingLimits,
   SettingLimits,
   Established,
@@ -583,8 +579,6 @@ const SessionState = {
     walletPublicKey,
     signMessage,
   }),
-
-  RestoringSession: () => ({ type: StateType.RestoringSession as const }),
 
   RequestingLimits: (
     onSubmitLimits: (limits?: Map<PublicKey, bigint>) => void,
@@ -639,7 +633,6 @@ const SESSION_STATE_NAME = {
   [StateType.SelectingWallet]: "SelectingWallet",
   [StateType.WalletConnecting]: "WalletConnecting",
   [StateType.CheckingStoredSession]: "CheckingStoredSession",
-  [StateType.RestoringSession]: "RestoringSession",
   [StateType.RequestingLimits]: "RequestingLimits",
   [StateType.SettingLimits]: "SettingLimits",
   [StateType.Established]: "Established",


### PR DESCRIPTION
This avoids showing the wallet popup when restoring the session, which has been very common feedback.  It makes sense to only show it when first establishing the session, where it's relevant context.