### PR TITLE
chore: set up default wallet adapters

### DIFF
--- a/packages/sessions-sdk-react/package.json
+++ b/packages/sessions-sdk-react/package.json
@@ -56,6 +56,7 @@
     "@phosphor-icons/react": "catalog:",
     "@react-hookz/web": "catalog:",
     "@solana/spl-token": "catalog:",
+    "@solana/wallet-adapter-backpack": "catalog:",
     "@solana/wallet-adapter-react": "catalog:",
     "@solana/wallet-adapter-react-ui": "catalog:",
     "@solana/wallet-adapter-wallets": "catalog:",

--- a/packages/sessions-sdk-react/src/session-button.tsx
+++ b/packages/sessions-sdk-react/src/session-button.tsx
@@ -92,7 +92,7 @@ export const SessionButton = ({
       }
       prevSessionState.current = sessionState;
     }
-  }, [sessionState.type]);
+  }, [sessionState]);
 
   return (
     <>

--- a/packages/sessions-sdk-react/src/session-provider.tsx
+++ b/packages/sessions-sdk-react/src/session-provider.tsx
@@ -14,6 +14,7 @@ import {
   getStoredSession,
   setStoredSession,
 } from "@fogo/sessions-sdk-web";
+import { BackpackWalletAdapter } from "@solana/wallet-adapter-backpack";
 import {
   ConnectionProvider,
   WalletProvider,
@@ -25,9 +26,9 @@ import {
   useWalletModal,
 } from "@solana/wallet-adapter-react-ui";
 import {
-  CoinbaseWalletAdapter,
-  LedgerWalletAdapter,
-  TorusWalletAdapter,
+  SolflareWalletAdapter,
+  PhantomWalletAdapter,
+  NightlyWalletAdapter,
 } from "@solana/wallet-adapter-wallets";
 import { PublicKey } from "@solana/web3.js";
 import type { ComponentProps, ReactNode } from "react";
@@ -83,9 +84,10 @@ export const FogoSessionProvider = ({
 }: Props) => {
   const wallets = useMemo(
     () => [
-      new CoinbaseWalletAdapter(),
-      new LedgerWalletAdapter(),
-      new TorusWalletAdapter(),
+      new NightlyWalletAdapter(),
+      new PhantomWalletAdapter(),
+      new BackpackWalletAdapter(),
+      new SolflareWalletAdapter(),
     ],
     [],
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ catalogs:
     '@solana/spl-token':
       specifier: ^0.4.13
       version: 0.4.13
+    '@solana/wallet-adapter-backpack':
+      specifier: 0.1.14
+      version: 0.1.14
     '@solana/wallet-adapter-base':
       specifier: ^0.9.23
       version: 0.9.27
@@ -506,6 +509,9 @@ importers:
       '@solana/spl-token':
         specifier: 'catalog:'
         version: 0.4.13(@solana/web3.js@1.98.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/wallet-adapter-backpack':
+        specifier: 'catalog:'
+        version: 0.1.14(@solana/web3.js@1.98.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-react':
         specifier: 'catalog:'
         version: 0.15.39(@solana/web3.js@1.98.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.1.8)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
@@ -3782,6 +3788,13 @@ packages:
     engines: {node: '>=20'}
     peerDependencies:
       '@solana/web3.js': ^1.98.0
+
+  '@solana/wallet-adapter-backpack@0.1.14':
+    resolution: {integrity: sha512-DfNLd5S1P7rmrgqMp+jRd21ryuXUxia1mu4qmZ+cau1NGFO2v5ep14LhzYXmqPde6kgbzPLPkLdRnkffLdI4TA==}
+    engines: {node: '>=16'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      '@solana/web3.js': ^1.77.3
 
   '@solana/wallet-adapter-base-ui@0.1.6':
     resolution: {integrity: sha512-OuxLBOXA2z3dnmuGP0agEb7xhsT3+Nttd+gAkSLgJRX2vgNEAy3Fvw8IKPXv1EE2vRdw/U6Rq0Yjpp3McqVZhw==}
@@ -14116,6 +14129,11 @@ snapshots:
       '@solana/web3.js': 1.98.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
 
   '@solana/wallet-adapter-avana@0.1.17(@solana/web3.js@1.98.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))
+      '@solana/web3.js': 1.98.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+
+  '@solana/wallet-adapter-backpack@0.1.14(@solana/web3.js@1.98.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,6 +23,7 @@ catalog:
   "@solana/compat": ^2.1.1
   "@solana/kit": ^2.1.1
   "@solana/spl-token": ^0.4.13
+  "@solana/wallet-adapter-backpack": 0.1.14
   "@solana/wallet-adapter-base": ^0.9.23
   "@solana/wallet-adapter-react": ^0.15.35
   "@solana/wallet-adapter-react-ui": ^0.9.35


### PR DESCRIPTION
This sets up the default wallet adapters to match those we advertise on https://www.fogo.io/start