### PR TITLE
Allow known-failing transactions to pass transaction validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,7 +1502,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fogo-paymaster"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,7 +1502,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fogo-paymaster"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1512,6 +1512,7 @@ dependencies = [
  "config",
  "serde",
  "solana-client",
+ "solana-commitment-config",
  "solana-keypair",
  "solana-packet",
  "solana-pubkey",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ codegen-units = 1
 anchor-lang = "0.31.1"
 anchor-spl = "0.31.1"
 solana-client = "2.2.1"
+solana-commitment-config = "2.2.1"
 solana-keypair = "2.2.1"
 solana-packet = "2.2.1"
 solana-pubkey = "2.2.1"

--- a/services/paymaster/Cargo.toml
+++ b/services/paymaster/Cargo.toml
@@ -12,6 +12,7 @@ clap ={version = "4.5.41", features = ["derive"]}
 config = "0.15.13"
 serde = "1.0.219"
 solana-client = {workspace = true}
+solana-commitment-config = {workspace = true}
 solana-keypair = {workspace = true}
 solana-packet = {workspace = true}
 solana-pubkey = {workspace = true}

--- a/services/paymaster/Cargo.toml
+++ b/services/paymaster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fogo-paymaster"
-version = "0.1.1"
+version = "0.1.2"
 edition = { workspace = true }
 
 [dependencies]

--- a/services/paymaster/Cargo.toml
+++ b/services/paymaster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fogo-paymaster"
-version = "0.1.2"
+version = "0.1.3"
 edition = { workspace = true }
 
 [dependencies]

--- a/services/paymaster/src/api.rs
+++ b/services/paymaster/src/api.rs
@@ -90,11 +90,11 @@ pub async fn validate_transaction(
             )
         })?;
 
-    if let Some(err) = simulation_result.value.err {
-        return Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Transaction simulation failed: {err:?}"),
-        ));
+    if let Some(_err) = simulation_result.value.err {
+        // The paymaster succeeds when the transaction simulation successfully determines that the
+        // transaction returns an error. This is a stopgap measure to unblock 3rd parties while we figure
+        // out the underlying problems with transaction simulation.
+        return Ok(())
     }
 
     // Check if the sponsor account balance change exceeds the maximum permissible value

--- a/services/paymaster/src/api.rs
+++ b/services/paymaster/src/api.rs
@@ -10,8 +10,9 @@ use axum::{
 use base64::Engine;
 use solana_client::rpc_client::RpcClient;
 use solana_client::rpc_config::{
-    RpcSendTransactionConfig, RpcSimulateTransactionAccountsConfig, RpcSimulateTransactionConfig,
+    RpcSendTransactionConfig, RpcSimulateTransactionAccountsConfig, RpcSimulateTransactionConfig
 };
+use solana_commitment_config::{CommitmentConfig, CommitmentLevel};
 use solana_keypair::Keypair;
 use solana_packet::PACKET_DATA_SIZE;
 use solana_pubkey::Pubkey;
@@ -72,6 +73,7 @@ pub async fn validate_transaction(
             RpcSimulateTransactionConfig {
                 sig_verify: false,
                 replace_recent_blockhash: true,
+                commitment: Some(CommitmentConfig { commitment: CommitmentLevel::Processed }),
                 accounts: Some(RpcSimulateTransactionAccountsConfig {
                     encoding: None,
                     addresses: vec![sponsor.to_string()],

--- a/services/paymaster/src/api.rs
+++ b/services/paymaster/src/api.rs
@@ -10,7 +10,7 @@ use axum::{
 use base64::Engine;
 use solana_client::rpc_client::RpcClient;
 use solana_client::rpc_config::{
-    RpcSendTransactionConfig, RpcSimulateTransactionAccountsConfig, RpcSimulateTransactionConfig
+    RpcSendTransactionConfig, RpcSimulateTransactionAccountsConfig, RpcSimulateTransactionConfig,
 };
 use solana_commitment_config::{CommitmentConfig, CommitmentLevel};
 use solana_keypair::Keypair;
@@ -73,7 +73,9 @@ pub async fn validate_transaction(
             RpcSimulateTransactionConfig {
                 sig_verify: false,
                 replace_recent_blockhash: true,
-                commitment: Some(CommitmentConfig { commitment: CommitmentLevel::Processed }),
+                commitment: Some(CommitmentConfig {
+                    commitment: CommitmentLevel::Processed,
+                }),
                 accounts: Some(RpcSimulateTransactionAccountsConfig {
                     encoding: None,
                     addresses: vec![sponsor.to_string()],


### PR DESCRIPTION
This PR is a stopgap measure to unblock users of the paymaster who are currently hitting errors. The old paymaster signed and submitted failing transactions, so by deploying this new paymaster, we've changed the API for end users. There are also some mysterious transaction simulation errors which we don't understand at the moment.

In the long term we don't want this behavior. However, that update will need an API change for the paymaster, which will take time to ship.