### PR TITLE
feat: add a callback for before starting the session init flow

### DIFF
--- a/.changeset/sharp-lizards-check.md
+++ b/.changeset/sharp-lizards-check.md
@@ -1,0 +1,5 @@
+---
+"@fogo/sessions-sdk-react": patch
+---
+
+Add the `onSessionStartInit` callback to `<FogoSessionProvider />` which can be used to trigger app code before starting the session init flow. The callback can be async and you can return `false` to indicate that the session init flow should not run.

--- a/packages/sessions-sdk-react/src/session-provider.tsx
+++ b/packages/sessions-sdk-react/src/session-provider.tsx
@@ -72,6 +72,10 @@ type Props = ConstrainedOmit<
     | undefined;
   enableUnlimited?: boolean | undefined;
   sponsor?: PublicKey | string | undefined;
+  onStartSessionInit?:
+    | (() => Promise<boolean> | boolean)
+    | (() => Promise<void> | void)
+    | undefined;
 };
 
 export const FogoSessionProvider = ({
@@ -119,11 +123,16 @@ const SessionProvider = ({
   children,
   defaultRequestedLimits,
   enableUnlimited,
+  onStartSessionInit,
   ...args
 }: Parameters<typeof useSessionStateContext>[0] & {
   children: ReactNode;
   defaultRequestedLimits?: Map<PublicKey, bigint> | undefined;
   enableUnlimited?: boolean | undefined;
+  onStartSessionInit?:
+    | (() => Promise<boolean> | boolean)
+    | (() => Promise<void> | void)
+    | undefined;
 }) => {
   const {
     state: sessionState,
@@ -136,8 +145,9 @@ const SessionProvider = ({
       sessionState,
       enableUnlimited: enableUnlimited ?? false,
       whitelistedTokens: args.tokens ?? [],
+      onStartSessionInit,
     }),
-    [sessionState, enableUnlimited, args.tokens],
+    [sessionState, enableUnlimited, args.tokens, onStartSessionInit],
   );
 
   return (
@@ -536,6 +546,10 @@ const SessionContext = createContext<
       sessionState: SessionState;
       enableUnlimited: boolean;
       whitelistedTokens: PublicKey[];
+      onStartSessionInit?:
+        | (() => Promise<boolean> | boolean)
+        | (() => Promise<void> | void)
+        | undefined;
     }
   | undefined
 >(undefined);


### PR DESCRIPTION
This commit adds a callback `onSessionStartInit` which can be optionally passed to trigger app behavior before starting the session initialization flow.  If passed, this callback can be an async function and can return `false` to indicate that initialization flow should not proceed.