### PR TITLE
feat: tollbooth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5946,6 +5946,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tollbooth"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "fogo-sessions-sdk",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1504,6 +1504,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 name = "fogo-paymaster"
 version = "0.1.3"
 dependencies = [
+ "anchor-lang",
  "anyhow",
  "axum",
  "base64 0.22.1",
@@ -1519,6 +1520,7 @@ dependencies = [
  "solana-signer",
  "solana-transaction",
  "tokio",
+ "tollbooth",
  "tower-http",
  "utoipa",
  "utoipa-axum",

--- a/Tiltfile
+++ b/Tiltfile
@@ -14,6 +14,8 @@ local_resource(
         ../target/deploy/chain_id.so \
         --bpf-program DomaLfEueNY6JrQSEFjuXeUDiohFmSrFeTNTPamS2yog \
         ../target/deploy/domain_registry.so \
+        --bpf-program 7czSB69NDz3QJSveAga7igHR86ZkESEou9q845xzPkgf \
+        ../target/deploy/tollbooth.so \
         --mint $(solana-keygen pubkey ./keypairs/faucet.json) \
         --bpf-program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA ./programs/spl_token.so \
         --account-dir ./accounts \

--- a/Tiltfile
+++ b/Tiltfile
@@ -49,7 +49,8 @@ LOOKUP_TABLE_ADDRESSES=[
     "akbpBKqNWBiZn3ejes3ejieJ5t3vqEhoq1ZzLBG7jQo",
     "GCUiTxhnGexbHj1kMFVzupjx4azktm12HNoePXjJmTLh",
     "6dM4TqWyWJsbx7obrdLcviBkTafD5E8av61zfU6jq57X",
-    "8MEFa571enhk3iTPsZML7ZxyM7edchbiwU3U1L1aAZBW"
+    "8MEFa571enhk3iTPsZML7ZxyM7edchbiwU3U1L1aAZBW",
+    "F9dJCJTGfepvFsyQTKb2B95XKspwUhcLGbUm7vE7vsbD"
 ]
 
 local_resource(

--- a/packages/sessions-idls/package.json
+++ b/packages/sessions-idls/package.json
@@ -27,7 +27,7 @@
     "build:esm": "swc src -d dist/esm --strip-leading-paths --copy-files -C jsc.experimental.keepImportAttributes=true && echo '{\"type\":\"module\"}' > dist/esm/package.json",
     "build:package-json": "transform-package-json ./package.json dist/package.json",
     "build:types": "tsc --project tsconfig.build.json",
-    "build:idl": "mkdir -p src/idl && mkdir -p src/types && anchor idl build --program-name session-manager --out-ts src/types/session-manager.ts --out src/idl/session-manager.json && anchor idl build --program-name example --out-ts src/types/example.ts --out src/idl/example.json && anchor idl build --program-name chain-id --out-ts src/types/chain-id.ts --out src/idl/chain-id.json && anchor idl build --program-name domain-registry --out-ts src/types/domain-registry.ts --out src/idl/domain-registry.json",
+    "build:idl": "mkdir -p src/idl && mkdir -p src/types && anchor idl build --program-name session-manager --out-ts src/types/session-manager.ts --out src/idl/session-manager.json && anchor idl build --program-name example --out-ts src/types/example.ts --out src/idl/example.json && anchor idl build --program-name chain-id --out-ts src/types/chain-id.ts --out src/idl/chain-id.json && anchor idl build --program-name domain-registry --out-ts src/types/domain-registry.ts --out src/idl/domain-registry.json && anchor idl build --program-name tollbooth --out-ts src/types/tollbooth.ts --out src/idl/tollbooth.json",
     "fix:format": "prettier --write .",
     "fix:lint": "eslint --fix . --max-warnings 0",
     "test:format": "run-jest --colors --selectProjects format",

--- a/packages/sessions-idls/src/index.ts
+++ b/packages/sessions-idls/src/index.ts
@@ -4,10 +4,12 @@ import ChainIdIdlImpl from "./idl/chain-id.json" with { type: "json" };
 import DomainRegistryIdlImpl from "./idl/domain-registry.json" with { type: "json" };
 import ExampleIdlImpl from "./idl/example.json" with { type: "json" };
 import SessionManagerIdlImpl from "./idl/session-manager.json" with { type: "json" };
+import TollboothIdlImpl from "./idl/tollbooth.json" with { type: "json" };
 import type { ChainId } from "./types/chain-id.js";
 import type { DomainRegistry } from "./types/domain-registry.js";
 import type { Example } from "./types/example.js";
 import type { SessionManager } from "./types/session-manager.js";
+import type { Tollbooth } from "./types/tollbooth.js";
 
 export type SessionManagerIdl = SessionManager;
 export const SessionManagerIdl = SessionManagerIdlImpl as SessionManagerIdl;
@@ -38,5 +40,13 @@ export const DomainRegistryIdl = DomainRegistryIdlImpl as DomainRegistryIdl;
 export class DomainRegistryProgram extends Program<DomainRegistryIdl> {
   constructor(provider: AnchorProvider) {
     super(DomainRegistryIdl, provider);
+  }
+}
+
+export type TollboothIdl = Tollbooth;
+export const TollboothIdl = TollboothIdlImpl as TollboothIdl;
+export class TollboothProgram extends Program<TollboothIdl> {
+  constructor(provider: AnchorProvider) {
+    super(TollboothIdl, provider);
   }
 }

--- a/programs/tollbooth/Cargo.toml
+++ b/programs/tollbooth/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "tollbooth"
+version = "0.1.0"
+edition = { workspace = true }
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "tollbooth"
+
+[features]
+default = []
+cpi = ["no-entrypoint"]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
+
+[dependencies]
+anchor-lang = { workspace = true }
+anchor-spl = { workspace = true }
+fogo-sessions-sdk = { path = "../../packages/sessions-sdk-rs" }

--- a/programs/tollbooth/src/lib.rs
+++ b/programs/tollbooth/src/lib.rs
@@ -17,8 +17,18 @@ pub mod tollbooth {
     }
 
     #[instruction(discriminator = [128])]
-    pub fn exit<'info>(ctx: Context<'_, '_, '_, 'info, Exit<'info>>, max_allowed_spending: u32) -> Result<()> {
-        require_gte!(ctx.accounts.sponsor.lamports().saturating_add(u64::from(max_allowed_spending)), ctx.accounts.sponsor_snapshot.lamports, ErrorCode::ExceededMaxAllowedSpending);
+    pub fn exit<'info>(
+        ctx: Context<'_, '_, '_, 'info, Exit<'info>>,
+        max_allowed_spending: u32,
+    ) -> Result<()> {
+        require_gte!(
+            ctx.accounts
+                .sponsor
+                .lamports()
+                .saturating_add(u64::from(max_allowed_spending)),
+            ctx.accounts.sponsor_snapshot.lamports,
+            ErrorCode::ExceededMaxAllowedSpending
+        );
         Ok(())
     }
 }
@@ -38,7 +48,6 @@ pub struct Exit<'info> {
     #[account(mut, close = sponsor, seeds = [SNAPSHOT_SEED, sponsor.key().as_ref()], bump)]
     pub sponsor_snapshot: Account<'info, BalanceSnapshot>,
 }
-
 
 #[account]
 pub struct BalanceSnapshot {

--- a/programs/tollbooth/src/lib.rs
+++ b/programs/tollbooth/src/lib.rs
@@ -1,0 +1,52 @@
+#![allow(unexpected_cfgs)] // warning: unexpected `cfg` condition value: `anchor-debug`
+
+use anchor_lang::prelude::*;
+
+declare_id!("7czSB69NDz3QJSveAga7igHR86ZkESEou9q845xzPkgf");
+
+const SNAPSHOT_SEED: &[u8] = b"snapshot";
+
+#[program]
+pub mod tollbooth {
+    use super::*;
+
+    #[instruction(discriminator = [0])]
+    pub fn enter<'info>(ctx: Context<'_, '_, '_, 'info, Enter<'info>>) -> Result<()> {
+        ctx.accounts.sponsor_snapshot.lamports = ctx.accounts.sponsor.lamports();
+        Ok(())
+    }
+
+    #[instruction(discriminator = [128])]
+    pub fn exit<'info>(ctx: Context<'_, '_, '_, 'info, Exit<'info>>, max_allowed_spending: u32) -> Result<()> {
+        require_gte!(ctx.accounts.sponsor.lamports().saturating_add(u64::from(max_allowed_spending)), ctx.accounts.sponsor_snapshot.lamports, ErrorCode::ExceededMaxAllowedSpending);
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Enter<'info> {
+    #[account(mut)]
+    pub sponsor: Signer<'info>,
+    #[account(init, payer = sponsor, space = 8 + 8, seeds = [SNAPSHOT_SEED, sponsor.key().as_ref()], bump)]
+    pub sponsor_snapshot: Account<'info, BalanceSnapshot>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct Exit<'info> {
+    pub sponsor: Signer<'info>,
+    #[account(mut, close = sponsor, seeds = [SNAPSHOT_SEED, sponsor.key().as_ref()], bump)]
+    pub sponsor_snapshot: Account<'info, BalanceSnapshot>,
+}
+
+
+#[account]
+pub struct BalanceSnapshot {
+    pub lamports: u64,
+}
+
+#[error_code]
+pub enum ErrorCode {
+    #[msg("This transaction exceeded the maximum allowed sponsor spending")]
+    ExceededMaxAllowedSpending,
+}

--- a/services/paymaster/Cargo.toml
+++ b/services/paymaster/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.3"
 edition = { workspace = true }
 
 [dependencies]
+anchor-lang = { workspace = true }
 anyhow = "1.0.98"
 axum = "0.8.4"
 base64 = "0.22.1"
@@ -19,6 +20,7 @@ solana-pubkey = {workspace = true}
 solana-signer = {workspace = true}
 solana-transaction = {workspace = true}
 tokio = {version = "1.46.1", features = ["full"]}
+tollbooth = { path = "../../programs/tollbooth" }
 tower-http = {version = "0.6.6", features = ["cors"]}
 utoipa = "5.4.0"
 utoipa-axum = "0.2.0"

--- a/services/paymaster/src/api.rs
+++ b/services/paymaster/src/api.rs
@@ -85,14 +85,14 @@ pub async fn validate_transaction(
             if !first_instruction.data.starts_with(Enter::DISCRIMINATOR) {
                 return Err((
                     StatusCode::BAD_REQUEST,
-                    format!("Invalid first instruction data, expected tollbooth Enter instruction"),
+                    "Invalid first instruction data, expected tollbooth Enter instruction".to_string(),
                 ));
             }
             
-            if !first_instruction.accounts.get(0).map(|index| transaction.message.static_account_keys().get(usize::from(*index))).flatten().map(|x| x == sponsor).unwrap_or_default(){
+            if !first_instruction.accounts.first().and_then(|index| transaction.message.static_account_keys().get(usize::from(*index))).map(|x| x == sponsor).unwrap_or_default(){
                 return Err((
                     StatusCode::BAD_REQUEST,
-                    format!("Enter instruction's sponsor must be the same as the paymaster's sponsor"),
+                    "Enter instruction's sponsor must be the same as the paymaster's sponsor".to_string(),
                 ));
             };
             
@@ -110,11 +110,11 @@ pub async fn validate_transaction(
             if !last_instruction.data.starts_with(Exit::DISCRIMINATOR) {
                 return Err((
                     StatusCode::BAD_REQUEST,
-                    format!("Invalid last instruction, expected tollbooth Exit instruction"),
+                    "Invalid last instruction, expected tollbooth Exit instruction".to_string(),
                 ));
             }
 
-            if let Some(exit) = last_instruction.data.get(1..).map(|x| Exit::try_from_slice(x).ok()).flatten() {
+            if let Some(exit) = last_instruction.data.get(1..).and_then(|x| Exit::try_from_slice(x).ok()) {
                     if u64::from(exit.max_allowed_spending) != max_sponsor_spending {
                         return Err((
                             StatusCode::BAD_REQUEST,
@@ -125,15 +125,15 @@ pub async fn validate_transaction(
                 else {
                     return Err((
                         StatusCode::BAD_REQUEST,
-                        format!("Invalid last instruction, failed to deserialize Exit instruction"),
+                        "Invalid last instruction, failed to deserialize Exit instruction".to_string(),
                     ));
                 }
             
                 
-            if !last_instruction.accounts.get(0).map(|index| transaction.message.static_account_keys().get(usize::from(*index))).flatten().map(|x| x == sponsor).unwrap_or_default(){
+            if !last_instruction.accounts.first().and_then(|index| transaction.message.static_account_keys().get(usize::from(*index))).map(|x| x == sponsor).unwrap_or_default(){
                     return Err((
                         StatusCode::BAD_REQUEST,
-                        format!("Exit instruction's sponsor must be the same as the paymaster's sponsor"),
+                        "Exit instruction's sponsor must be the same as the paymaster's sponsor".to_string(),
                     ));
                 };
             
@@ -143,7 +143,7 @@ pub async fn validate_transaction(
                     if instruction.program_id(transaction.message.static_account_keys()) == &TOLLBOOTH_PROGRAM_ID {
                         return Err((
                             StatusCode::BAD_REQUEST,
-                            format!("Tollbooth instructions must be the first and last instruction only"),
+                            "Tollbooth instructions must be the first and last instruction only".to_string(),
                         ));
                     }
                 }

--- a/tilt/configs/paymaster.toml
+++ b/tilt/configs/paymaster.toml
@@ -6,5 +6,6 @@ program_whitelist = [
     "Examtz9qAwhxcADNFodNA2QpxK7SM9bCHyiaUvWvFBM3",
     "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
     "Ed25519SigVerify111111111111111111111111111",
-    "SesswvJ7puvAgpyqp7N8HnjNnvpnS8447tKNF3sPgbC"
+    "SesswvJ7puvAgpyqp7N8HnjNnvpnS8447tKNF3sPgbC",
+    "7czSB69NDz3QJSveAga7igHR86ZkESEou9q845xzPkgf"
 ]


### PR DESCRIPTION
This PR introduces the tollbooth program, a program that caps the spend of the paymaster in each sponsored transaction.

For transactions to be sponsored by the paymaster they need to add a `tollboth::Enter` instruction as their first instruction and `tollboth::Exit` as their last instruction.

In a first stage, we can use it to remove transaction simulation from the paymaster server, reducing latency.
It also enables a fully sustainable paymaster by setting max_sponsor_spending to 0. We will work to make this mode easier for apps in a future PR. 