### PR TITLE
fix: use the same commitment for simulation and get balance

### DIFF
--- a/services/paymaster/src/api.rs
+++ b/services/paymaster/src/api.rs
@@ -224,7 +224,12 @@ pub async fn run_server(config: Config) {
         )
         .with_state(Arc::new(ServerState {
             keypair,
-            rpc: RpcClient::new_with_commitment(config.solana_url, CommitmentConfig { commitment: CommitmentLevel::Processed }),
+            rpc: RpcClient::new_with_commitment(
+                config.solana_url,
+                CommitmentConfig {
+                    commitment: CommitmentLevel::Processed,
+                },
+            ),
             program_whitelist: config.program_whitelist,
             max_sponsor_spending: config.max_sponsor_spending,
         }));

--- a/services/paymaster/src/api.rs
+++ b/services/paymaster/src/api.rs
@@ -224,7 +224,7 @@ pub async fn run_server(config: Config) {
         )
         .with_state(Arc::new(ServerState {
             keypair,
-            rpc: RpcClient::new(config.solana_url),
+            rpc: RpcClient::new_with_commitment(config.solana_url, CommitmentConfig { commitment: CommitmentLevel::Processed }),
             program_whitelist: config.program_whitelist,
             max_sponsor_spending: config.max_sponsor_spending,
         }));


### PR DESCRIPTION
The default commitment is `finalized`. I think this was leading to `get_balance` returning the balance from a deeper block than the one we simulate against, causing an overestimation of the paymaster spend.