### PR TITLE
fix: replace react-timeago with a custom component

### DIFF
--- a/.changeset/heavy-bushes-wash.md
+++ b/.changeset/heavy-bushes-wash.md
@@ -1,0 +1,5 @@
+---
+"@fogo/sessions-sdk-react": patch
+---
+
+Relpace react-timeago with a custom component

--- a/packages/sessions-sdk-react/package.json
+++ b/packages/sessions-sdk-react/package.json
@@ -67,7 +67,6 @@
     "modern-normalize": "catalog:",
     "qrcode.react": "catalog:",
     "react-aria-components": "catalog:",
-    "react-timeago": "catalog:",
     "swr": "catalog:",
     "zod": "catalog:"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,9 +189,6 @@ catalogs:
     react-dom:
       specifier: ^19.0.1
       version: 19.1.1
-    react-timeago:
-      specifier: ^8.3.0
-      version: 8.3.0
     sass:
       specifier: ^1.89.2
       version: 1.89.2
@@ -548,9 +545,6 @@ importers:
       react-aria-components:
         specifier: 'catalog:'
         version: 1.10.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      react-timeago:
-        specifier: 'catalog:'
-        version: 8.3.0(react@19.1.1)
       swr:
         specifier: 'catalog:'
         version: 2.3.3(react@19.1.1)
@@ -8835,11 +8829,6 @@ packages:
     resolution: {integrity: sha512-/8JC3Tmj7G8fHn47F88c6t5kFNhQAufwqjEKxYeNi7TPz9UL+35BeoH1poMmDHJsPz8qM/z4sWMzaW5AwYK8lQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  react-timeago@8.3.0:
-    resolution: {integrity: sha512-BeR0hj/5qqTc2+zxzBSQZMky6MmqwOtKseU3CSmcjKR5uXerej2QY34v2d+cdz11PoeVfAdWLX+qjM/UdZkUUg==}
-    peerDependencies:
-      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react@19.1.1:
     resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
@@ -21449,10 +21438,6 @@ snapshots:
       '@react-stately/tooltip': 3.5.5(react@19.1.1)
       '@react-stately/tree': 3.9.0(react@19.1.1)
       '@react-types/shared': 3.30.0(react@19.1.1)
-      react: 19.1.1
-
-  react-timeago@8.3.0(react@19.1.1):
-    dependencies:
       react: 19.1.1
 
   react@19.1.1: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -66,7 +66,6 @@ catalog:
   react-aria: ^3.41.1
   react-aria-components: ^1.10.1
   react-dom: ^19.0.1
-  react-timeago: ^8.3.0
   sass: ^1.89.2
   stylelint: ^16.21.0
   stylelint-config-standard-scss: ^15.0.1


### PR DESCRIPTION
The `react-timeago` library does not ship esm correctly and it's caused issues for the typing, and some of the developers using the sdk have reported that they can't use the latest release due to issues with their environment interacting with this library.

It's a pretty simple component.  Rather than fighting with the library to get it to work correctly, I figure it's better to just home-roll this.