### PR TITLE
fix: fix z-indexing issues

### DIFF
--- a/.changeset/tender-knives-sit.md
+++ b/.changeset/tender-knives-sit.md
@@ -1,0 +1,5 @@
+---
+"@fogo/sessions-sdk-react": patch
+---
+
+Apply more z-index fixes

--- a/packages/sessions-sdk-react/src/session-button.module.scss
+++ b/packages/sessions-sdk-react/src/session-button.module.scss
@@ -30,6 +30,7 @@
     transition:
       transform 200ms,
       opacity 200ms;
+    z-index: theme.layer("session-panel") !important;
 
     .overlayArrow {
       display: block;

--- a/packages/sessions-sdk-react/src/session-limits.module.scss
+++ b/packages/sessions-sdk-react/src/session-limits.module.scss
@@ -113,6 +113,7 @@
     color: theme.color("panel", "text");
     padding: theme.spacing(1) 0;
     min-width: var(--trigger-width);
+    z-index: theme.layer("select") !important;
 
     .selectItem {
       @include theme.text("sm", "normal");

--- a/packages/sessions-sdk-react/src/theme.scss
+++ b/packages/sessions-sdk-react/src/theme.scss
@@ -89,8 +89,10 @@ $border-radius: (
 // since that z-index also applies to the wallet popup and we want modal dialogs
 // to go above the wallet popup always.
 $layer: (
-  "modal-dialog": 999999,
-  "toast": 9999999,
+  "session-panel": 999996,
+  "modal-dialog": 999997,
+  "select": 999998,
+  "toast": 999999,
 );
 
 @function layer($value) {


### PR DESCRIPTION
Some teams are still reporting issues with z-indexing in some places.  The issue is that react-aria sometimes sets a z-index on some of the overlay elements, but it's inconsistent and often not a high enough z-index.

The fix is to override react-aria's z-indexing using our layering system.  It's unfortunate that we have to use `!important`, but react-aria sets the z-index on the element directly so we have no other choice.