### PR TITLE
feat: add basic rate limit management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,6 +1527,7 @@ dependencies = [
  "dashmap 6.1.0",
  "domain-registry",
  "fogo-sessions-sdk",
+ "redis",
  "serde",
  "serde_with",
  "solana-address-lookup-table-interface",
@@ -1974,7 +1975,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2958,7 +2959,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.29",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -2997,7 +2998,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -3144,6 +3145,22 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redis"
+version = "0.32.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd3650deebc68526b304898b192fa4102a4ef0b9ada24da096559cb60e0eef8"
+dependencies = [
+ "combine",
+ "itoa",
+ "num-bigint 0.4.6",
+ "percent-encoding",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.6.0",
+ "url",
 ]
 
 [[package]]
@@ -3681,6 +3698,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3761,6 +3784,16 @@ checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4416,7 +4449,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_derive",
- "socket2",
+ "socket2 0.5.10",
  "solana-serde",
  "tokio",
  "url",
@@ -5075,7 +5108,7 @@ dependencies = [
  "rand 0.8.5",
  "rustls 0.23.29",
  "smallvec",
- "socket2",
+ "socket2 0.5.10",
  "solana-keypair",
  "solana-measure",
  "solana-metrics",
@@ -5961,7 +5994,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2",
+ "socket2 0.5.10",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ To jump straight to examples, go to [here](https://github.com/fogo-foundation/fo
 tilt up # Starts local test validators, starts demo app
 ```
 
+As part of tilt, to run the redis server locally, you should make sure you have `redis-server` installed (`brew install redis` or `apt-get install redis-server`).
+
 ### Programs
 
 ```

--- a/Tiltfile
+++ b/Tiltfile
@@ -75,9 +75,14 @@ local_resource(
 )
 
 local_resource(
+    "redis",
+    serve_cmd="redis-server --port 6379 --save '' --appendonly no",
+)
+
+local_resource(
     "paymaster",
     serve_cmd="cargo run -p fogo-paymaster",
-    resource_deps=["svm-localnet"],
+    resource_deps=["svm-localnet", "redis"],
 )
 
 local_resource(

--- a/services/paymaster/Cargo.toml
+++ b/services/paymaster/Cargo.toml
@@ -15,6 +15,7 @@ config = "0.15.13"
 dashmap = "6.1.0"
 domain-registry = { path = "../../programs/domain-registry" }
 fogo-sessions-sdk = {workspace = true}
+redis = "0.32.5"
 serde = "1.0.219"
 serde_with = { version = "3.14.0", features = ["base64"] }
 solana-address-lookup-table-interface = {workspace = true}

--- a/services/paymaster/src/api.rs
+++ b/services/paymaster/src/api.rs
@@ -48,6 +48,7 @@ pub struct ServerState {
     pub max_sponsor_spending: u64,
     pub domains: HashMap<String, DomainState>,
     pub chain_index: ChainIndex,
+    pub redis_client: redis::Client,
 }
 
 impl ChainIndex {
@@ -138,6 +139,7 @@ impl DomainState {
         transaction: &VersionedTransaction,
         chain_index: &ChainIndex,
         max_sponsor_spending: u64,
+        client: &redis::Client,
     ) -> Result<(), (StatusCode, String)> {
         if transaction.message.static_account_keys()[0] != self.sponsor.pubkey() {
             return Err((
@@ -170,7 +172,7 @@ impl DomainState {
             })?;
 
         let matches_variation = self.tx_variations.iter().any(|variation| {
-            self.validate_transaction_against_variation(transaction, variation, chain_index)
+            self.validate_transaction_against_variation(transaction, variation, chain_index, client)
                 .is_ok()
         });
         if !matches_variation {
@@ -246,6 +248,7 @@ impl DomainState {
         transaction: &VersionedTransaction,
         tx_variation: &TransactionVariation,
         chain_index: &ChainIndex,
+        client: &redis::Client,
     ) -> Result<(), (StatusCode, String)> {
         match tx_variation {
             TransactionVariation::V0(variation) => variation.validate_transaction(transaction),
@@ -256,6 +259,7 @@ impl DomainState {
                     sponsor: self.sponsor.pubkey(),
                 },
                 chain_index,
+                client,
             ),
         }
     }
@@ -351,7 +355,12 @@ async fn sponsor_and_send_handler(
         .map_err(|_| (StatusCode::BAD_REQUEST, "Failed to deserialize transaction"))?;
 
     domain_state
-        .validate_transaction(&transaction, &state.chain_index, state.max_sponsor_spending)
+        .validate_transaction(
+            &transaction,
+            &state.chain_index,
+            state.max_sponsor_spending,
+            &state.redis_client,
+        )
         .await?;
 
     transaction.signatures[0] = domain_state
@@ -420,6 +429,7 @@ pub async fn run_server(
         mnemonic_file,
         solana_url,
         max_sponsor_spending,
+        redis_url,
         domains,
         listen_address,
     }: Config,
@@ -495,6 +505,7 @@ pub async fn run_server(
                 rpc,
                 lookup_table_cache: DashMap::new(),
             },
+            redis_client: redis::Client::open(redis_url).expect("Failed to create Redis client"),
         }));
     let listener = tokio::net::TcpListener::bind(listen_address).await.unwrap();
     axum::serve(listener, app).await.unwrap();

--- a/services/paymaster/src/config.rs
+++ b/services/paymaster/src/config.rs
@@ -29,6 +29,7 @@ pub struct Config {
     // However, in the config file, specify a number of FOGO -- the deserializer will auto-convert to lamports.
     #[serde(deserialize_with = "deserialize_sol_to_lamports")]
     pub max_sponsor_spending: u64,
+    pub redis_url: String,
     pub domains: Vec<Domain>,
 }
 

--- a/tilt/configs/paymaster.toml
+++ b/tilt/configs/paymaster.toml
@@ -2,6 +2,7 @@ mnemonic_file = "./tilt/secrets/mnemonic"
 solana_url = "http://127.0.0.1:8899"
 listen_address = "0.0.0.0:4000"
 max_sponsor_spending = 0.01
+redis_url = "redis://127.0.0.1:6379"
 
 [[domains]]
 domain = "http://localhost:3000"
@@ -16,7 +17,6 @@ max_gas_spend = 1000000
 
 [domains.tx_variations.rate_limits]
 session_per_min = 5
-ip_per_min = 20
 
 # Instruction 0
 [[domains.tx_variations.instructions]]


### PR DESCRIPTION
This PR adds basic rate limit management, using Redis for shared state. It uses a fixed window counter to keep track of usage.

TODOs for later PRs:

- [ ] Fixed window -> Token bucket (might require some nontrivial configuration)
- [ ] Add IP rate limits to app
- [ ] Instantiate real Redis for prod