### PR TITLE
feat: close sessions

### DIFF
--- a/packages/sessions-sdk-rs/src/session/mod.rs
+++ b/packages/sessions-sdk-rs/src/session/mod.rs
@@ -262,11 +262,12 @@ impl Session {
         Ok(())
     }
 
-    /// Returns whether the session is live
+    /// Returns whether the session is live. Revoked sessions are considered live until their expiration time.
     pub fn is_live(&self) -> Result<bool, SessionError> {
         Ok(Clock::get()
-                .map_err(|_| SessionError::ClockError)?
-                .unix_timestamp <= self.expiration()?)
+            .map_err(|_| SessionError::ClockError)?
+            .unix_timestamp
+            <= self.expiration()?)
     }
 
     /// This function checks that a session is live and authorized to interact with program `program_id` and returns the public key of the user who started the session

--- a/packages/sessions-sdk-rs/src/session/mod.rs
+++ b/packages/sessions-sdk-rs/src/session/mod.rs
@@ -231,14 +231,11 @@ impl Session {
     }
 
     fn check_is_live(&self) -> Result<(), SessionError> {
-        if self.expiration()?
-            < Clock::get()
-                .map_err(|_| SessionError::ClockError)?
-                .unix_timestamp
-        {
-            return Err(SessionError::Expired);
+        if self.is_live()? {
+            Ok(())
+        } else {
+            Err(SessionError::Expired)
         }
-        Ok(())
     }
 
     fn check_authorized_program(&self, program_id: &Pubkey) -> Result<(), SessionError> {
@@ -263,6 +260,13 @@ impl Session {
             return Err(SessionError::InvalidAccountVersion);
         }
         Ok(())
+    }
+
+    /// Returns whether the session is live
+    pub fn is_live(&self) -> Result<bool, SessionError> {
+        Ok(Clock::get()
+                .map_err(|_| SessionError::ClockError)?
+                .unix_timestamp <= self.expiration()?)
     }
 
     /// This function checks that a session is live and authorized to interact with program `program_id` and returns the public key of the user who started the session

--- a/programs/session-manager/src/error.rs
+++ b/programs/session-manager/src/error.rs
@@ -40,6 +40,8 @@ pub enum SessionManagerError {
     DomainRecordMismatch,
     #[msg("The provided sponsor account doesn't match the session sponsor")]
     SponsorMismatch,
+    #[msg("Only expired session accounts can be closed")]
+    SessionIsLive,
 }
 
 impl From<IntentError<<Message as TryFrom<Vec<u8>>>::Error>> for SessionManagerError {

--- a/programs/session-manager/src/lib.rs
+++ b/programs/session-manager/src/lib.rs
@@ -112,8 +112,15 @@ pub mod session_manager {
         Ok(())
     }
 
-    /// This is just to trick anchor into generating the IDL for the Session account since we don't use it in the context for `start_session`
     #[instruction(discriminator = [2])]
+    pub fn close_session<'info>(
+        _ctx: Context<'_, '_, '_, 'info, CloseSession<'info>>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    /// This is just to trick anchor into generating the IDL for the Session account since we don't use it in the context for `start_session`
+    #[instruction(discriminator = [3])]
     pub fn _unused<'info>(_ctx: Context<'_, '_, '_, 'info, Unused<'info>>) -> Result<()> {
         err!(ErrorCode::InstructionDidNotDeserialize)
     }
@@ -148,6 +155,17 @@ pub struct RevokeSession<'info> {
     pub sponsor: AccountInfo<'info>,
     pub system_program: Program<'info, System>,
 }
+
+#[derive(Accounts)]
+pub struct CloseSession<'info> {
+    #[account(mut, close = sponsor, constraint = !session.is_live()? @ SessionManagerError::SessionIsLive)]
+    pub session: Account<'info, Session>,
+    #[account(constraint = session.sponsor == sponsor.key() @ SessionManagerError::SponsorMismatch)]
+    /// CHECK: we check it against the session's sponsor
+    pub sponsor: AccountInfo<'info>,
+    pub system_program: Program<'info, System>,
+}
+
 #[derive(Accounts)]
 pub struct Unused<'info> {
     pub session: Account<'info, Session>,


### PR DESCRIPTION
This PR adds the functionality to close sessions to the on-chain program.
Only sessions whose expiration has passed can be closed definitively. 
This is because otherwise the intent that was used to create the session can be reused to recreate it.