### PR TITLE
refactor: remove simulation from paymaster

### DIFF
--- a/services/paymaster/src/config.rs
+++ b/services/paymaster/src/config.rs
@@ -3,7 +3,6 @@ use config::File;
 use serde::Deserialize;
 
 use crate::constraint::TransactionVariation;
-use crate::serde::deserialize_sol_to_lamports;
 
 #[derive(Deserialize)]
 pub struct Domain {
@@ -24,11 +23,6 @@ pub struct Config {
     pub mnemonic_file: String,
     pub solana_url: String,
     pub listen_address: String,
-    // The maximum amount that the sponsor can spend on a transaction.
-    // The value in the struct is expressed in lamports.
-    // However, in the config file, specify a number of FOGO -- the deserializer will auto-convert to lamports.
-    #[serde(deserialize_with = "deserialize_sol_to_lamports")]
-    pub max_sponsor_spending: u64,
     pub domains: Vec<Domain>,
 }
 

--- a/services/paymaster/src/serde.rs
+++ b/services/paymaster/src/serde.rs
@@ -12,15 +12,3 @@ where
         .map(|s| Pubkey::from_str(&s).map_err(serde::de::Error::custom))
         .collect()
 }
-
-pub fn deserialize_sol_to_lamports<'de, D>(deserializer: D) -> Result<u64, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let sol_value: f64 = f64::deserialize(deserializer)?;
-
-    // Convert SOL to lamports (1 SOL = 1,000,000,000 lamports)
-    let lamports = (sol_value * 1_000_000_000.0) as u64;
-
-    Ok(lamports)
-}

--- a/tilt/configs/paymaster.toml
+++ b/tilt/configs/paymaster.toml
@@ -1,7 +1,6 @@
 mnemonic_file = "./tilt/secrets/mnemonic"
 solana_url = "http://127.0.0.1:8899"
 listen_address = "0.0.0.0:4000"
-max_sponsor_spending = 0.01
 
 [[domains]]
 domain = "http://localhost:3000"


### PR DESCRIPTION
This PR removes simulation from the paymaster. This is in line with the shift to imperative constraints and checks and removes potentially expensive RPC calls from the paymaster logic.