### PR TITLE
fix: improve signer constraints

### DIFF
--- a/services/paymaster/src/constraint.rs
+++ b/services/paymaster/src/constraint.rs
@@ -53,7 +53,6 @@ impl VariationProgramWhitelist {
 pub struct VariationOrderedInstructionConstraints {
     pub name: String,
     pub instructions: Vec<InstructionConstraint>,
-    pub rate_limits: RateLimits,
     pub max_gas_spend: u64,
 }
 
@@ -103,12 +102,6 @@ impl VariationOrderedInstructionConstraints {
 
         Ok(())
     }
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct RateLimits {
-    pub session_per_min: Option<u64>,
-    pub ip_per_min: Option<u64>,
 }
 
 #[serde_as]

--- a/services/paymaster/src/constraint.rs
+++ b/services/paymaster/src/constraint.rs
@@ -255,7 +255,6 @@ pub enum ContextualPubkey {
         pubkey: Pubkey,
     },
     Sponsor,
-    FeePayer,
     NonFeePayerSigner,
     DomainRegistry,
 }
@@ -280,21 +279,6 @@ impl ContextualPubkey {
                             format!("Instruction {instruction_index}: Account {account} is not explicitly included")
                         } else {
                             format!("Instruction {instruction_index}: Account {account} is explicitly excluded")
-                        },
-                    ))
-                }
-            }
-
-            ContextualPubkey::FeePayer => {
-                if expect_include == (account == signers.first().expect("No signatures in transaction")) {
-                    Ok(())
-                } else {
-                    Err((
-                        StatusCode::BAD_REQUEST,
-                        if expect_include {
-                            format!("Instruction {instruction_index}: Account {account} is not the fee payer")
-                        } else {
-                            format!("Instruction {instruction_index}: Account {account} should be excluded as the fee payer")
                         },
                     ))
                 }

--- a/services/paymaster/src/constraint.rs
+++ b/services/paymaster/src/constraint.rs
@@ -283,7 +283,7 @@ impl ContextualPubkey {
                     ))
                 }
             }
-            
+
             ContextualPubkey::NonFeePayerSigner => {
                 if expect_include == (signers.iter().skip(1).any(|s| s == account)) {
                     Ok(())

--- a/services/paymaster/src/constraint_templates.rs
+++ b/services/paymaster/src/constraint_templates.rs
@@ -1,6 +1,6 @@
 use crate::constraint::{
     AccountConstraint, ContextualPubkey, DataConstraint, DataConstraintSpecification,
-    InstructionConstraint, PrimitiveDataType, PrimitiveDataValue, RateLimits, TransactionVariation,
+    InstructionConstraint, PrimitiveDataType, PrimitiveDataValue, TransactionVariation,
     VariationOrderedInstructionConstraints,
 };
 
@@ -150,10 +150,6 @@ impl TransactionVariation {
                 InstructionConstraint::intent_instruction_constraint(),
                 InstructionConstraint::start_session_instruction_constraint(),
             ],
-            rate_limits: RateLimits {
-                session_per_min: None,
-                ip_per_min: None,
-            },
             max_gas_spend: 100_000,
         })
     }
@@ -163,10 +159,6 @@ impl TransactionVariation {
         TransactionVariation::V1(VariationOrderedInstructionConstraints {
             name: "Session Revocation".to_string(),
             instructions: vec![InstructionConstraint::revoke_session_instruction_constraint()],
-            rate_limits: RateLimits {
-                session_per_min: None,
-                ip_per_min: None,
-            },
             max_gas_spend: 100_000,
         })
     }

--- a/services/paymaster/src/constraint_templates.rs
+++ b/services/paymaster/src/constraint_templates.rs
@@ -92,7 +92,7 @@ impl InstructionConstraint {
                 },
                 AccountConstraint {
                     index: 2,
-                    include: vec![ContextualPubkey::Signer { index: -1 }],
+                    include: vec![ContextualPubkey::NonFeePayerSigner],
                     exclude: vec![],
                 },
             ],
@@ -117,7 +117,7 @@ impl InstructionConstraint {
             accounts: vec![
                 AccountConstraint {
                     index: 0,
-                    include: vec![ContextualPubkey::Signer { index: -1 }],
+                    include: vec![ContextualPubkey::NonFeePayerSigner],
                     exclude: vec![],
                 },
                 AccountConstraint {

--- a/tilt/configs/paymaster.toml
+++ b/tilt/configs/paymaster.toml
@@ -20,7 +20,7 @@ required = true
 
 [[domains.tx_variations.instructions.accounts]]
 index = 2
-include = [ { Signer = { index = -1 } } ]
+include = [ { NonFeePayerSigner = {} } ]
 exclude = []
 
 [[domains.tx_variations.instructions.accounts]]
@@ -28,7 +28,7 @@ index = 1
 include = []
 exclude = [
     { Explicit = { pubkey = "So11111111111111111111111111111111111111111" } },
-    { Signer = { index = -1 } }
+    { NonFeePayerSigner = {} }
 ]
 
 [[domains.tx_variations.instructions.data]]
@@ -44,7 +44,7 @@ required = true
 
 [[domains.tx_variations.instructions.accounts]]
 index = 0
-include = [ { Signer = { index = -1 } } ]
+include = [ { NonFeePayerSigner = {} } ]
 exclude = []
 
 [[domains.tx_variations.instructions.data]]

--- a/tilt/configs/paymaster.toml
+++ b/tilt/configs/paymaster.toml
@@ -13,10 +13,6 @@ version = "v1"
 name = "Sample v1 Variation"
 max_gas_spend = 1000000
 
-[domains.tx_variations.rate_limits]
-session_per_min = 5
-ip_per_min = 20
-
 # Instruction 0
 [[domains.tx_variations.instructions]]
 program = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"


### PR DESCRIPTION
This PR improves the signer constraints given that signer order (besides the fee payer) is not easily derivable when there are more than 2 non-fee-paying signers.