### PR TITLE
feat: add bytes primitive data to paymaster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,6 +1527,7 @@ dependencies = [
  "dashmap 6.1.0",
  "domain-registry",
  "fogo-sessions-sdk",
+ "hex",
  "serde",
  "serde_with",
  "solana-address-lookup-table-interface",

--- a/services/paymaster/Cargo.toml
+++ b/services/paymaster/Cargo.toml
@@ -15,6 +15,7 @@ config = "0.15.13"
 dashmap = "6.1.0"
 domain-registry = { path = "../../programs/domain-registry" }
 fogo-sessions-sdk = {workspace = true}
+hex = "0.4.3"
 serde = "1.0.219"
 serde_with = { version = "3.14.0", features = ["base64"] }
 solana-address-lookup-table-interface = {workspace = true}

--- a/services/paymaster/src/constraint.rs
+++ b/services/paymaster/src/constraint.rs
@@ -415,7 +415,9 @@ impl DataConstraint {
                 PrimitiveDataValue::Pubkey(data_pubkey)
             }
 
-            PrimitiveDataType::Bytes { length: expected_length } => {
+            PrimitiveDataType::Bytes {
+                length: expected_length,
+            } => {
                 if data_to_analyze.len() != expected_length {
                     return Err((
                         StatusCode::BAD_REQUEST,
@@ -454,7 +456,9 @@ pub enum PrimitiveDataType {
     Bool,
     Pubkey,
     /// Fixed-size byte array
-    Bytes { length: usize },
+    Bytes {
+        length: usize,
+    },
 }
 
 impl PrimitiveDataType {


### PR DESCRIPTION
This PR adds an option for bytes to the `PrimitiveDataType` and `PrimitiveDataValue` types. This allows apps to more easily specify discriminators and other byte strings in their constraints.