### PR TITLE
Fix: remove implicit compute budget

### DIFF
--- a/services/paymaster/src/constraint.rs
+++ b/services/paymaster/src/constraint.rs
@@ -113,7 +113,8 @@ impl VariationOrderedInstructionConstraints {
                 transaction,
                 instruction_index,
                 &solana_compute_budget_interface::id(),
-            ).unwrap_or(false);
+            )
+            .unwrap_or(false);
 
             if is_compute_budget_ix {
                 instruction_index += 1;

--- a/services/paymaster/src/constraint.rs
+++ b/services/paymaster/src/constraint.rs
@@ -654,7 +654,9 @@ pub fn check_gas_spend(
 /// Extracts the compute unit price and limit from the instructions. Uses default values if not set.
 /// If multiple compute budget instructions are present, the validation will fail.
 /// If compute budget instructions have invalid data, the validation will fail.
-pub fn process_compute_budget_instructions(transaction: &VersionedTransaction) -> Result<u64, (StatusCode, String)> {
+pub fn process_compute_budget_instructions(
+    transaction: &VersionedTransaction,
+) -> Result<u64, (StatusCode, String)> {
     let mut cu_limit = None;
     let mut micro_lamports_per_cu = None;
 

--- a/services/paymaster/src/constraint.rs
+++ b/services/paymaster/src/constraint.rs
@@ -72,17 +72,20 @@ pub struct ContextualDomainKeys {
     pub sponsor: Pubkey,
 }
 
-fn is_compute_budget_instruction(transaction: &VersionedTransaction, instruction_index: usize) -> bool {
+fn is_compute_budget_instruction(
+    transaction: &VersionedTransaction,
+    instruction_index: usize,
+) -> bool {
     if let Some(instruction) = transaction.message.instructions().get(instruction_index) {
         let static_accounts = transaction.message.static_account_keys();
         let program_id = instruction.program_id(static_accounts);
-        if program_id == &solana_compute_budget_interface::id() {
-            if let Ok(_) = ComputeBudgetInstruction::try_from_slice(&instruction.data) {
-                return true;
-            }
+        if program_id == &solana_compute_budget_interface::id()
+            && ComputeBudgetInstruction::try_from_slice(&instruction.data).is_ok()
+        {
+            return true;
         }
     }
-    
+
     false
 }
 
@@ -99,7 +102,7 @@ impl VariationOrderedInstructionConstraints {
 
         // Note: this validation algorithm is technically incorrect, because of optional constraints.
         // E.g. instruction i might match against both constraint j and constraint j+1; if constraint j
-        // is optional, it might be possible that matching against j leads to failure due to later 
+        // is optional, it might be possible that matching against j leads to failure due to later
         // constraints failing while matching against j+1 would result in a valid transaction match.
         // Technically, the correct way to validate this is via branching (efficiently via DP), but given
         // the expected variation space and a desire to avoid complexity, we use this greedy approach.

--- a/services/paymaster/src/constraint.rs
+++ b/services/paymaster/src/constraint.rs
@@ -97,6 +97,12 @@ impl VariationOrderedInstructionConstraints {
         let mut constraint_index = 0;
         check_gas_spend(transaction, self.max_gas_spend)?;
 
+        // Note: this validation algorithm is technically incorrect, because of optional constraints.
+        // E.g. instruction i might match against both constraint j and constraint j+1; if constraint j
+        // is optional, it might be possible that matching against j leads to failure due to later 
+        // constraints failing while matching against j+1 would result in a valid transaction match.
+        // Technically, the correct way to validate this is via branching (efficiently via DP), but given
+        // the expected variation space and a desire to avoid complexity, we use this greedy approach.
         while constraint_index < self.instructions.len() {
             if is_compute_budget_instruction(transaction, instruction_index) {
                 instruction_index += 1;

--- a/services/paymaster/src/constraint.rs
+++ b/services/paymaster/src/constraint.rs
@@ -148,6 +148,10 @@ impl InstructionConstraint {
 
         let program_id = instruction.program_id(static_accounts);
         if *program_id != self.program {
+            // we allow Compute Budget instructions anywhere. Compute Budget is implicitly checked for v1 variations in check_gas_spend.
+            if program_id == &solana_compute_budget_interface::id() {
+                return Ok(());
+            }
             return Err((
                 StatusCode::BAD_REQUEST,
                 format!(

--- a/services/paymaster/src/constraint.rs
+++ b/services/paymaster/src/constraint.rs
@@ -147,11 +147,11 @@ impl InstructionConstraint {
         let signatures = &transaction.signatures;
 
         let program_id = instruction.program_id(static_accounts);
+        // we allow Compute Budget instructions anywhere. Compute Budget is implicitly checked for v1 variations in check_gas_spend.
+        if program_id == &solana_compute_budget_interface::id() {
+            return Ok(());
+        }
         if *program_id != self.program {
-            // we allow Compute Budget instructions anywhere. Compute Budget is implicitly checked for v1 variations in check_gas_spend.
-            if program_id == &solana_compute_budget_interface::id() {
-                return Ok(());
-            }
             return Err((
                 StatusCode::BAD_REQUEST,
                 format!(

--- a/tilt/configs/paymaster.toml
+++ b/tilt/configs/paymaster.toml
@@ -56,12 +56,16 @@ constraint = { EqualTo = [ {U8 = 4}, {U8 = 5} ] }
 
 ## Tx Variation 1
 [[domains.tx_variations]]
-version = "v0"
-name = "Sample v0 Variation"
-whitelisted_programs = [
-    "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL", 
-    "Examtz9qAwhxcADNFodNA2QpxK7SM9bCHyiaUvWvFBM3", 
-    "Ed25519SigVerify111111111111111111111111111", 
-    "SesswvJ7puvAgpyqp7N8HnjNnvpnS8447tKNF3sPgbC", 
-    "Xfry4dW9m42ncAqm8LyEnyS5V6xu5DSJTMRQLiGkARD"
-]
+version = "v1"
+name = "Example v1 Variation"
+max_gas_spend = 1000000
+
+# Instruction 0
+[[domains.tx_variations.instructions]]
+program = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+required = false
+
+# Instruction 1
+[[domains.tx_variations.instructions]]
+program = "Examtz9qAwhxcADNFodNA2QpxK7SM9bCHyiaUvWvFBM3"
+required = true


### PR DESCRIPTION
Previously, Compute Budget instructions needed to be specified in v1 transaction variations. However, given the `max_gas_spend` check, this is unnecessary, and apps do not need to specify allowing Compute Budget instructions.

In addition to the `SetComputeUnitLimit` and `SetComputeUnitPrice` instructions, there are also `RequestHeapFrame` and `SetLoadedAccountsDataSizeLimit` instructions (and a deprecated `RequestUnits` instruction). These do not add to the gas cost, and they are not commonly used. Preventing use of these instructions does not appear to be critical at this time; if apps request, we can filter to only permit `SetComputeUnitLimit` and `SetComputeUnitPrice` instructions arbitrarily.