### PR TITLE
Fix: include account constraint

### DIFF
--- a/services/paymaster/src/constraint.rs
+++ b/services/paymaster/src/constraint.rs
@@ -288,15 +288,29 @@ impl AccountConstraint {
             )
         })?;
 
-        self.include.iter().try_for_each(|included| {
-            included.matches_account(
-                account,
-                &signers,
-                contextual_domain_keys,
-                true,
-                instruction_index,
-            )
-        })?;
+        if !self.include.is_empty() {
+            let matches_any = self
+                .include
+                .iter()
+                .any(|included| {
+                    included.matches_account(
+                        account,
+                        &signers,
+                        contextual_domain_keys,
+                        true,
+                        instruction_index,
+                    ).is_ok()
+                });
+
+            if !matches_any {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    format!(
+                        "Instruction {instruction_index}: Account {account} does not match any include constraints",
+                    ),
+                ));
+            }
+        }
 
         Ok(())
     }

--- a/services/paymaster/src/constraint.rs
+++ b/services/paymaster/src/constraint.rs
@@ -278,6 +278,7 @@ impl AccountConstraint {
         contextual_domain_keys: &ContextualDomainKeys,
         instruction_index: usize,
     ) -> Result<(), (StatusCode, String)> {
+        // excludes are AND-gated: all excludes must be satisfied
         self.exclude.iter().try_for_each(|excluded| {
             excluded.matches_account(
                 account,
@@ -288,19 +289,19 @@ impl AccountConstraint {
             )
         })?;
 
+        // includes are OR-gated: at least one include must be satisfied
         if !self.include.is_empty() {
-            let matches_any = self
-                .include
-                .iter()
-                .any(|included| {
-                    included.matches_account(
+            let matches_any = self.include.iter().any(|included| {
+                included
+                    .matches_account(
                         account,
                         &signers,
                         contextual_domain_keys,
                         true,
                         instruction_index,
-                    ).is_ok()
-                });
+                    )
+                    .is_ok()
+            });
 
             if !matches_any {
                 return Err((


### PR DESCRIPTION
This PR fixes a bug in the include account constraints. Previously, the include account constraints were being checked as if they were AND gated. They should be checked as OR gated constraints (just one needs to be satisfied).