### PR TITLE
refactor: paymaster deprecate confirm option

### DIFF
--- a/packages/sessions-sdk-ts/src/adapter.ts
+++ b/packages/sessions-sdk-ts/src/adapter.ts
@@ -240,7 +240,6 @@ const sendToPaymaster = async (
       "/api/sponsor_and_send",
       options.paymaster ?? DEFAULT_PAYMASTER,
     );
-    url.searchParams.set("confirm", "true");
     url.searchParams.set("domain", domain);
     const response = await fetch(url, {
       method: "POST",

--- a/services/paymaster/src/api.rs
+++ b/services/paymaster/src/api.rs
@@ -210,7 +210,7 @@ impl DomainState {
 #[serde(deny_unknown_fields)]
 #[into_params(parameter_in = Query)]
 struct SponsorAndSendQuery {
-    #[serde(default)]
+    #[serde(default, rename = "confirm")]
     #[deprecated]
     /// Whether to confirm the transaction
     _confirm: bool,

--- a/services/paymaster/src/api.rs
+++ b/services/paymaster/src/api.rs
@@ -322,7 +322,6 @@ async fn sponsor_and_send_handler(
         .sign_message(&transaction.message.serialize());
     tracing::Span::current().record("tx_hash", transaction.signatures[0].to_string());
 
-
     let confirmation_result = send_and_confirm_transaction(
         &state.chain_index.rpc,
         &transaction,
@@ -343,12 +342,7 @@ async fn sponsor_and_send_handler(
     );
 
     let gas = crate::constraint::compute_gas_spent(&transaction)?;
-    obs_gas_spend(
-        domain,
-        matched_variation_name,
-        confirmation_status,
-        gas,
-    );
+    obs_gas_spend(domain, matched_variation_name, confirmation_status, gas);
 
     Ok(confirmation_result)
 }

--- a/services/paymaster/src/api.rs
+++ b/services/paymaster/src/api.rs
@@ -211,6 +211,10 @@ impl DomainState {
 #[into_params(parameter_in = Query)]
 struct SponsorAndSendQuery {
     #[serde(default)]
+    #[deprecated]
+    /// Whether to confirm the transaction
+    _confirm: bool,
+    #[serde(default)]
     /// Domain to request the sponsor pubkey for
     domain: Option<String>,
 }
@@ -282,7 +286,7 @@ async fn readiness_handler() -> StatusCode {
 async fn sponsor_and_send_handler(
     State(state): State<Arc<ServerState>>,
     origin: Option<TypedHeader<Origin>>,
-    Query(SponsorAndSendQuery { domain }): Query<SponsorAndSendQuery>,
+    Query(SponsorAndSendQuery { domain, .. }): Query<SponsorAndSendQuery>,
     Json(payload): Json<SponsorAndSendPayload>,
 ) -> Result<SponsorAndSendResponse, ErrorResponse> {
     let domain = get_domain_name(domain, origin)?;

--- a/services/paymaster/src/api.rs
+++ b/services/paymaster/src/api.rs
@@ -274,7 +274,7 @@ async fn sponsor_and_send_handler(
     origin: Option<TypedHeader<Origin>>,
     Query(SponsorAndSendQuery { domain, .. }): Query<SponsorAndSendQuery>,
     Json(payload): Json<SponsorAndSendPayload>,
-) -> Result<ConfirmationResult, ErrorResponse> {
+) -> Result<Json<ConfirmationResult>, ErrorResponse> {
     let domain = get_domain_name(domain, origin)?;
     tracing::Span::current().record("domain", domain.as_str());
     let domain_state = get_domain_state(&state, &domain)?;
@@ -344,7 +344,7 @@ async fn sponsor_and_send_handler(
     let gas = crate::constraint::compute_gas_spent(&transaction)?;
     obs_gas_spend(domain, matched_variation_name, confirmation_status, gas);
 
-    Ok(confirmation_result)
+    Ok(Json(confirmation_result))
 }
 
 #[derive(serde::Deserialize, utoipa::IntoParams)]

--- a/services/paymaster/src/api.rs
+++ b/services/paymaster/src/api.rs
@@ -353,14 +353,14 @@ async fn sponsor_and_send_handler(
     obs_send(
         domain.clone(),
         matched_variation_name.clone(),
-        Some(confirmation_status.clone()),
+        confirmation_status.clone(),
     );
 
     let gas = crate::constraint::compute_gas_spent(&transaction)?;
     obs_gas_spend(
         domain,
         matched_variation_name,
-        Some(confirmation_status),
+        confirmation_status,
         gas,
     );
 

--- a/services/paymaster/src/metrics.rs
+++ b/services/paymaster/src/metrics.rs
@@ -12,7 +12,11 @@ pub fn obs_validation(domain: String, variation: String, result_validation: Stri
 
 pub const TRANSACTION_SEND_COUNT: &str = "paymaster_transaction_send_total";
 pub fn obs_send(domain: String, variation: String, result_confirmation: String) {
-    let labels = vec![("domain", domain), ("variation", variation), ("result", result_confirmation)];
+    let labels = vec![
+        ("domain", domain),
+        ("variation", variation),
+        ("result", result_confirmation),
+    ];
     metrics::counter!(TRANSACTION_SEND_COUNT, &labels).increment(1);
 }
 
@@ -33,6 +37,10 @@ pub fn obs_gas_spend(
     result_confirmation: String,
     lamports: u64,
 ) {
-    let labels = vec![("domain", domain), ("variation", variation), ("result", result_confirmation)];
+    let labels = vec![
+        ("domain", domain),
+        ("variation", variation),
+        ("result", result_confirmation),
+    ];
     metrics::histogram!(GAS_SPEND_HISTOGRAM, &labels).record(lamports as f64);
 }

--- a/services/paymaster/src/metrics.rs
+++ b/services/paymaster/src/metrics.rs
@@ -11,11 +11,8 @@ pub fn obs_validation(domain: String, variation: String, result_validation: Stri
 }
 
 pub const TRANSACTION_SEND_COUNT: &str = "paymaster_transaction_send_total";
-pub fn obs_send(domain: String, variation: String, result_confirmation: Option<String>) {
-    let mut labels = vec![("domain", domain), ("variation", variation)];
-    if let Some(result) = result_confirmation {
-        labels.push(("result", result));
-    }
+pub fn obs_send(domain: String, variation: String, result_confirmation: String) {
+    let labels = vec![("domain", domain), ("variation", variation), ("result", result_confirmation)];
     metrics::counter!(TRANSACTION_SEND_COUNT, &labels).increment(1);
 }
 
@@ -33,12 +30,9 @@ pub const GAS_SPEND_BUCKETS: &[f64] = &[
 pub fn obs_gas_spend(
     domain: String,
     variation: String,
-    result_confirmation: Option<String>,
+    result_confirmation: String,
     lamports: u64,
 ) {
-    let mut labels = vec![("domain", domain), ("variation", variation)];
-    if let Some(result) = result_confirmation {
-        labels.push(("result", result));
-    }
+    let labels = vec![("domain", domain), ("variation", variation), ("result", result_confirmation)];
     metrics::histogram!(GAS_SPEND_HISTOGRAM, &labels).record(lamports as f64);
 }

--- a/services/paymaster/src/rpc.rs
+++ b/services/paymaster/src/rpc.rs
@@ -1,4 +1,8 @@
-use axum::{http::StatusCode, response::{ErrorResponse, IntoResponse, Response}, Json};
+use axum::{
+    http::StatusCode,
+    response::{ErrorResponse, IntoResponse, Response},
+    Json,
+};
 use solana_client::{rpc_client::RpcClient, rpc_config::RpcSendTransactionConfig};
 use solana_commitment_config::CommitmentConfig;
 use solana_hash::Hash;

--- a/services/paymaster/src/rpc.rs
+++ b/services/paymaster/src/rpc.rs
@@ -1,8 +1,4 @@
-use axum::{
-    http::StatusCode,
-    response::{ErrorResponse, IntoResponse, Response},
-    Json,
-};
+use axum::{http::StatusCode, response::ErrorResponse};
 use solana_client::{rpc_client::RpcClient, rpc_config::RpcSendTransactionConfig};
 use solana_commitment_config::CommitmentConfig;
 use solana_hash::Hash;
@@ -25,12 +21,6 @@ pub enum ConfirmationResult {
         signature: String,
         error: TransactionError,
     },
-}
-
-impl IntoResponse for ConfirmationResult {
-    fn into_response(self) -> Response {
-        Json(self).into_response()
-    }
 }
 
 impl ConfirmationResult {

--- a/services/paymaster/src/rpc.rs
+++ b/services/paymaster/src/rpc.rs
@@ -1,4 +1,4 @@
-use axum::{http::StatusCode, response::ErrorResponse};
+use axum::{http::StatusCode, response::{ErrorResponse, IntoResponse, Response}, Json};
 use solana_client::{rpc_client::RpcClient, rpc_config::RpcSendTransactionConfig};
 use solana_commitment_config::CommitmentConfig;
 use solana_hash::Hash;
@@ -21,6 +21,12 @@ pub enum ConfirmationResult {
         signature: String,
         error: TransactionError,
     },
+}
+
+impl IntoResponse for ConfirmationResult {
+    fn into_response(self) -> Response {
+        Json(self).into_response()
+    }
 }
 
 impl ConfirmationResult {


### PR DESCRIPTION
This PR deprecates the `confirm` flag in the `sponsor_and_send` query. Eventually we should disable the argument altogether, after users have all upgraded to the next version of the SDK.