### PR TITLE
fix: configure otlp endpoint w env var

### DIFF
--- a/services/paymaster/README.md
+++ b/services/paymaster/README.md
@@ -33,7 +33,7 @@ v1 does not enforce relationships across instructions (e.g. require instruction 
 
 ## Metrics and Logs
 
-The paymaster service records some metrics via Prometheus and some spans for timing of the transaction validation/submission/confirmation flow via OpenTelemetry. The service exports these OpenTelemetry spans to `localhost:4317`.
+The paymaster service records some metrics via Prometheus and some spans for timing of the transaction validation/submission/confirmation flow via OpenTelemetry. The service exports these OpenTelemetry spans to `localhost:4317` by default. You can configure sending these to a different destination by setting the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable.
 
 You can run a local all in one jaeger instance to collect and visualize these spans by running:
 

--- a/services/paymaster/src/main.rs
+++ b/services/paymaster/src/main.rs
@@ -1,6 +1,7 @@
 use crate::config::load_config;
 use clap::Parser;
 use opentelemetry::trace::TracerProvider;
+use opentelemetry_otlp::WithExportConfig;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 mod api;
@@ -29,8 +30,12 @@ async fn main() -> anyhow::Result<()> {
         )])
         .build();
 
+    let otlp_endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
+        .unwrap_or_else(|_| "http://localhost:4317".to_string());
+
     let exporter = opentelemetry_otlp::SpanExporter::builder()
         .with_tonic()
+        .with_endpoint(otlp_endpoint)
         .build()?;
 
     let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()


### PR DESCRIPTION
This PR checks for an OTLP endpoint env var to which to send spans.