### PR TITLE
fix: set wallet widget height on mobile

### DIFF
--- a/.changeset/tired-bags-mate.md
+++ b/.changeset/tired-bags-mate.md
@@ -1,0 +1,5 @@
+---
+"@fogo/sessions-sdk-react": patch
+---
+
+Set wallet widget height on mobile

--- a/packages/sessions-sdk-react/src/session-button.module.scss
+++ b/packages/sessions-sdk-react/src/session-button.module.scss
@@ -174,6 +174,7 @@
 
     .sessionPanel {
       width: 100%;
+      height: theme.spacing(148);
       max-height: 80dvh;
       border-top-left-radius: theme.border-radius("xl");
       border-top-right-radius: theme.border-radius("xl");
@@ -186,7 +187,6 @@
 
       @include theme.breakpoint("sm") {
         width: theme.spacing(88);
-        height: theme.spacing(148);
         border-radius: theme.border-radius("xl");
       }
 


### PR DESCRIPTION
This PR fixes a very small issue I noticed where empty wallets / wallets with few tokens look awkwardly scrunched on the mobile view.  We just set a static height for the widget (and there's already a max-height of 80dvh so we don't overflow the screen)