### PR TITLE
fix: add templates to constraints during loading

### DIFF
--- a/services/paymaster/src/api.rs
+++ b/services/paymaster/src/api.rs
@@ -394,9 +394,9 @@ pub async fn run_server(
         .map(
             |Domain {
                  domain,
-                 enable_session_management,
                  enable_preflight_simulation,
                  tx_variations,
+                 ..
              }| {
                 let domain_registry_key = domain_registry::domain::Domain::new_checked(&domain)
                     .expect("Failed to derive domain registry key")
@@ -409,21 +409,6 @@ pub async fn run_server(
                 )
                 .expect("Failed to derive keypair from mnemonic_file");
 
-                let tx_variations = tx_variations
-                    .into_iter()
-                    .chain(
-                        enable_session_management
-                            .then(|| {
-                                [
-                                    TransactionVariation::session_establishment_variation(),
-                                    TransactionVariation::session_revocation_variation(),
-                                ]
-                            })
-                            .into_iter()
-                            .flatten(),
-                    )
-                    .chain([TransactionVariation::intent_transfer_variation()])
-                    .collect();
                 (
                     domain,
                     DomainState {

--- a/services/paymaster/src/config.rs
+++ b/services/paymaster/src/config.rs
@@ -40,10 +40,16 @@ pub fn load_config(config_path: &str) -> Result<Config> {
 
     for domain in &mut config.domains {
         if domain.enable_session_management {
-            domain.tx_variations.push(TransactionVariation::session_establishment_variation());
-            domain.tx_variations.push(TransactionVariation::session_revocation_variation());
+            domain
+                .tx_variations
+                .push(TransactionVariation::session_establishment_variation());
+            domain
+                .tx_variations
+                .push(TransactionVariation::session_revocation_variation());
         }
-        domain.tx_variations.push(TransactionVariation::intent_transfer_variation());
+        domain
+            .tx_variations
+            .push(TransactionVariation::intent_transfer_variation());
     }
 
     Ok(config)

--- a/services/paymaster/src/config.rs
+++ b/services/paymaster/src/config.rs
@@ -33,9 +33,18 @@ pub struct Config {
 }
 
 pub fn load_config(config_path: &str) -> Result<Config> {
-    let config: Config = config::Config::builder()
+    let mut config: Config = config::Config::builder()
         .add_source(File::with_name(config_path))
         .build()?
         .try_deserialize()?;
+
+    for domain in &mut config.domains {
+        if domain.enable_session_management {
+            domain.tx_variations.push(TransactionVariation::session_establishment_variation());
+            domain.tx_variations.push(TransactionVariation::session_revocation_variation());
+        }
+        domain.tx_variations.push(TransactionVariation::intent_transfer_variation());
+    }
+
     Ok(config)
 }


### PR DESCRIPTION
This PR adds templates to the constraints in the paymaster config during the initial loading. This is the best implementation bc it alleviates the developer from having to manually add these in later. 

There aren't really any expected use cases where someone would want to exclude the templates from the constraints, although we could add that functionality later via an argument in the load function if needed.