### PR TITLE
fix: paymaster async rpc client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1582,6 +1582,7 @@ dependencies = [
  "domain-registry",
  "fogo-sessions-sdk",
  "futures",
+ "governor",
  "hex",
  "intent-transfer",
  "opentelemetry",

--- a/services/paymaster/Cargo.toml
+++ b/services/paymaster/Cargo.toml
@@ -18,6 +18,7 @@ dashmap = "6.1.0"
 domain-registry = { path = "../../programs/domain-registry" }
 fogo-sessions-sdk = {workspace = true}
 futures = "0.3.31"
+governor = "0.6.3"
 hex = "0.4.3"
 intent-transfer = {workspace = true, features = ["no-entrypoint"]}
 opentelemetry = "0.30.0"

--- a/services/paymaster/src/api.rs
+++ b/services/paymaster/src/api.rs
@@ -17,7 +17,7 @@ use axum_prometheus::PrometheusMetricLayer;
 use base64::Engine;
 use dashmap::DashMap;
 use solana_address_lookup_table_interface::state::AddressLookupTable;
-use solana_client::rpc_client::RpcClient;
+use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_client::rpc_config::RpcSendTransactionConfig;
 use solana_commitment_config::{CommitmentConfig, CommitmentLevel};
 use solana_derivation_path::DerivationPath;
@@ -51,7 +51,7 @@ pub struct ServerState {
 
 impl ChainIndex {
     /// Finds the lookup table and the index within that table that correspond to the given relative account position within the list of lookup invoked accounts.
-    pub fn find_and_query_lookup_table(
+    pub async fn find_and_query_lookup_table(
         &self,
         lookup_accounts: Vec<(Pubkey, u8)>,
         account_position_lookups: usize,
@@ -63,26 +63,29 @@ impl ChainIndex {
                     format!("Account position {account_position_lookups} out of bounds for lookup table invoked accounts"),
                 )
             })?;
-        self.query_lookup_table_with_retry(table_to_query, usize::from(*index_to_query))
+        self.query_lookup_table_with_retry(table_to_query, usize::from(*index_to_query)).await
     }
 
     /// Queries the lookup table for the pubkey at the given index.
     /// If the table is not cached or the index is out of bounds, it fetches and updates the table from the RPC before requerying.
-    pub fn query_lookup_table_with_retry(
+    pub async fn query_lookup_table_with_retry(
         &self,
         table: &Pubkey,
         index: usize,
     ) -> Result<Pubkey, (StatusCode, String)> {
-        self.query_lookup_table(table, index).or_else(|_| {
-            let addresses = self.update_lookup_table(table)?;
-            // get the key from the returned addresses instead of re-querying and re-locking the map
-            addresses.get(index).copied().ok_or_else(|| {
-                (
-                    StatusCode::BAD_REQUEST,
-                    format!("Lookup table {table} does not contain index {index}"),
-                )
-            })
-        })
+        match self.query_lookup_table(table, index) {
+            Ok(pubkey) => Ok(pubkey),
+            Err(_) => {
+                let addresses = self.update_lookup_table(table).await?;
+                // get the key from the returned addresses instead of re-querying and re-locking the map
+                addresses.get(index).copied().ok_or_else(|| {
+                    (
+                        StatusCode::BAD_REQUEST,
+                        format!("Lookup table {table} does not contain index {index}"),
+                    )
+                })
+            }
+        }
     }
 
     /// Queries the lookup table for the pubkey at the given index.
@@ -104,8 +107,8 @@ impl ChainIndex {
     }
 
     // Updates the lookup table entry in the dashmap based on pulling from RPC. Returns the updated table data.
-    pub fn update_lookup_table(&self, table: &Pubkey) -> Result<Vec<Pubkey>, (StatusCode, String)> {
-        let table_data = self.rpc.get_account(table).map_err(|err| {
+    pub async fn update_lookup_table(&self, table: &Pubkey) -> Result<Vec<Pubkey>, (StatusCode, String)> {
+        let table_data = self.rpc.get_account(table).await.map_err(|err| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("Failed to fetch lookup table account {table} from RPC: {err}"),
@@ -171,22 +174,25 @@ impl DomainState {
                     })
             })?;
 
-        let matched = self.tx_variations.iter().find(|variation| {
-            self.validate_transaction_against_variation(transaction, variation, chain_index)
-                .is_ok()
-        });
-        if let Some(variation) = matched {
-            tracing::Span::current().record("variation", variation.name().to_string());
-            Ok(variation)
-        } else {
-            Err((
+        let validation_futures: Vec<_> = self.tx_variations.iter().map(|variation| {
+            Box::pin(async move {
+                self.validate_transaction_against_variation(transaction, variation, chain_index).await.map(|_| variation)
+            })
+        }).collect();
+
+        match futures::future::select_ok(validation_futures).await {
+            Ok((variation, _remaining)) => {
+                tracing::Span::current().record("variation", variation.name().to_string());
+                Ok(variation)
+            }
+            Err(_) => Err((
                 StatusCode::BAD_REQUEST,
                 "Transaction does not match any allowed variations".to_string(),
-            ))
+            )),
         }
     }
 
-    pub fn validate_transaction_against_variation(
+    pub async fn validate_transaction_against_variation(
         &self,
         transaction: &VersionedTransaction,
         tx_variation: &TransactionVariation,
@@ -201,7 +207,7 @@ impl DomainState {
                     sponsor: self.sponsor.pubkey(),
                 },
                 chain_index,
-            ),
+            ).await,
         }
     }
 }

--- a/services/paymaster/src/api.rs
+++ b/services/paymaster/src/api.rs
@@ -91,11 +91,7 @@ impl ChainIndex {
 
     /// Queries the lookup table for the pubkey at the given index.
     /// Returns None if the table is not cached or the index is out of bounds.
-    pub fn query_lookup_table(
-        &self,
-        table: &Pubkey,
-        index: usize,
-    ) -> Option<Pubkey> {
+    pub fn query_lookup_table(&self, table: &Pubkey, index: usize) -> Option<Pubkey> {
         self.lookup_table_cache
             .get(table)
             .and_then(|entry| entry.get(index).copied())

--- a/services/paymaster/src/bin/tx_validator.rs
+++ b/services/paymaster/src/bin/tx_validator.rs
@@ -66,7 +66,7 @@ async fn main() -> Result<()> {
             recent_sponsor_txs,
             rpc_concurrency,
         } => {
-            let config = load_and_filter_config(&config, &domain)?;
+            let config = load_config(&config)?;
             let domains = get_domains_for_validation(&config, &domain);
             let solana_url = config.solana_url.clone();
             let chain_index = ChainIndex {
@@ -109,22 +109,6 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-fn load_and_filter_config(
-    config_path: &str,
-    domain: &Option<String>,
-) -> Result<fogo_paymaster::config::Config> {
-    let config = load_config(config_path)
-        .with_context(|| format!("Failed to load config from {config_path}"))?;
-
-    if let Some(domain_name) = domain {
-        if !config.domains.iter().any(|d| d.domain == *domain_name) {
-            return Err(anyhow!("Domain '{domain_name}' not found in config"));
-        }
-    }
-
-    Ok(config)
-}
-
 fn get_domains_for_validation<'a>(
     config: &'a fogo_paymaster::config::Config,
     domain: &Option<String>,
@@ -134,7 +118,7 @@ fn get_domains_for_validation<'a>(
             .domains
             .iter()
             .find(|d| d.domain == *domain_name)
-            .expect("Domain should exist - validated in load_and_filter_config")]
+            .expect(format!("Domain '{domain_name}' not found in config").as_str())]
     } else {
         config.domains.iter().collect()
     }

--- a/services/paymaster/src/bin/tx_validator.rs
+++ b/services/paymaster/src/bin/tx_validator.rs
@@ -16,7 +16,7 @@ use solana_client::{
 use solana_signature::Signature;
 use solana_transaction::versioned::VersionedTransaction;
 use solana_transaction_status_client_types::UiTransactionEncoding;
-use std::{collections::HashMap, num::NonZeroU32, str::FromStr, sync::Arc};
+use std::{collections::HashMap, num::NonZeroU32, str::FromStr};
 
 use fogo_paymaster::{
     api::ChainIndex,
@@ -84,10 +84,10 @@ async fn main() -> Result<()> {
                 lookup_table_cache: DashMap::new(),
             };
 
-            let rpc_limiter = Arc::new(RateLimiter::direct(Quota::per_second(
+            let rpc_limiter = RateLimiter::direct(Quota::per_second(
                 NonZeroU32::new(rpc_quota_per_second)
                     .expect("RPC quota per second must be greater than zero"),
-            )));
+            ));
 
             let (transactions, is_batch) = fetch_transactions(
                 recent_sponsor_txs,
@@ -150,7 +150,7 @@ async fn fetch_transactions(
     domain: &Option<String>,
     domains: &[&Domain],
     chain_index: &ChainIndex,
-    rpc_limiter: &Arc<RpcRateLimiter>,
+    rpc_limiter: &RpcRateLimiter,
 ) -> Result<(Vec<VersionedTransaction>, bool)> {
     if let Some(limit) = recent_sponsor_txs {
         let domain_for_sponsor = if let Some(domain_name) = domain {
@@ -301,7 +301,7 @@ fn print_summary(validation_counts: HashMap<(String, String), usize>, failure_co
 async fn fetch_transaction_from_rpc(
     tx_hash: Signature,
     rpc_client: &RpcClient,
-    rpc_limiter: &Arc<RpcRateLimiter>,
+    rpc_limiter: &RpcRateLimiter,
 ) -> Result<VersionedTransaction> {
     let config = RpcTransactionConfig {
         encoding: Some(UiTransactionEncoding::Base64),
@@ -328,7 +328,7 @@ async fn fetch_recent_sponsor_signatures(
     sponsor_pubkey: &solana_pubkey::Pubkey,
     mut number: usize,
     rpc_client: &RpcClient,
-    rpc_limiter: &Arc<RpcRateLimiter>,
+    rpc_limiter: &RpcRateLimiter,
 ) -> Result<Vec<Signature>> {
     let mut signatures = Vec::new();
     let mut before = None;
@@ -370,7 +370,7 @@ async fn fetch_recent_sponsor_transactions(
     sponsor_pubkey: &solana_pubkey::Pubkey,
     number: usize,
     rpc_client: &RpcClient,
-    rpc_limiter: &Arc<RpcRateLimiter>,
+    rpc_limiter: &RpcRateLimiter,
 ) -> Result<Vec<VersionedTransaction>> {
     let signatures_to_fetch =
         fetch_recent_sponsor_signatures(sponsor_pubkey, number, rpc_client, rpc_limiter).await?;

--- a/services/paymaster/src/constraint.rs
+++ b/services/paymaster/src/constraint.rs
@@ -93,7 +93,7 @@ fn instruction_matches_program(
 }
 
 impl VariationOrderedInstructionConstraints {
-    pub fn validate_transaction(
+    pub async fn validate_transaction(
         &self,
         transaction: &VersionedTransaction,
         contextual_domain_keys: &ContextualDomainKeys,
@@ -129,7 +129,7 @@ impl VariationOrderedInstructionConstraints {
                 contextual_domain_keys,
                 &self.name,
                 chain_index,
-            );
+            ).await;
 
             if result.is_err() {
                 if constraint.required {
@@ -169,7 +169,7 @@ pub struct InstructionConstraint {
 }
 
 impl InstructionConstraint {
-    pub fn validate_instruction(
+    pub async fn validate_instruction(
         &self,
         transaction: &VersionedTransaction,
         instruction_index: usize,
@@ -231,7 +231,7 @@ impl InstructionConstraint {
                     .collect();
                 let account_position_lookups = account_index - static_accounts.len();
                 &chain_index
-                    .find_and_query_lookup_table(lookup_accounts, account_position_lookups)?
+                    .find_and_query_lookup_table(lookup_accounts, account_position_lookups).await?
             } else {
                 return Err((
                     StatusCode::BAD_REQUEST,

--- a/services/paymaster/src/constraint.rs
+++ b/services/paymaster/src/constraint.rs
@@ -123,13 +123,15 @@ impl VariationOrderedInstructionConstraints {
             }
 
             let constraint = &self.instructions[constraint_index];
-            let result = constraint.validate_instruction(
-                transaction,
-                instruction_index,
-                contextual_domain_keys,
-                &self.name,
-                chain_index,
-            ).await;
+            let result = constraint
+                .validate_instruction(
+                    transaction,
+                    instruction_index,
+                    contextual_domain_keys,
+                    &self.name,
+                    chain_index,
+                )
+                .await;
 
             if result.is_err() {
                 if constraint.required {
@@ -231,7 +233,8 @@ impl InstructionConstraint {
                     .collect();
                 let account_position_lookups = account_index - static_accounts.len();
                 &chain_index
-                    .find_and_query_lookup_table(lookup_accounts, account_position_lookups).await?
+                    .find_and_query_lookup_table(lookup_accounts, account_position_lookups)
+                    .await?
             } else {
                 return Err((
                     StatusCode::BAD_REQUEST,


### PR DESCRIPTION
This PR transitions to using a nonblocking RPC client. This allows for concurrent RPC calls and speeds up the transaction validator CLI tool. It also introduces basic rate limiting to accommodate concurrent requests.

In the future, we may wish to attempt retries on RPC calls, but we leave that for another PR.