### PR TITLE
fix: use effect retrigger

### DIFF
--- a/.changeset/rare-swans-hope.md
+++ b/.changeset/rare-swans-hope.md
@@ -1,0 +1,5 @@
+---
+"@fogo/sessions-sdk-react": patch
+---
+
+Fix bug causing the checkStoredSession callback to get triggered multiple times

--- a/packages/sessions-sdk-react/src/components/session-provider.tsx
+++ b/packages/sessions-sdk-react/src/components/session-provider.tsx
@@ -622,7 +622,7 @@ const useSessionStateContext = ({
         return;
       }
     }
-  }, [state, checkStoredSession, disconnectWallet]);
+  }, [state]);
 
   useEffect(() => {
     setState(


### PR DESCRIPTION
This fixes the bug with the react sdk behaving poorly after restarting the local validator.
It doesn't make sense to trigger this when the callbacks change since:
- we want this to trigger when `StateType.CheckingStoredSession` is entered
- useEffect will use the latest versions of the callbacks no matter what