### PR TITLE
fix: generalize paymastter template gas spend

### DIFF
--- a/services/paymaster/src/config.rs
+++ b/services/paymaster/src/config.rs
@@ -44,14 +44,20 @@ pub fn load_config(config_path: &str) -> Result<Config> {
         if domain.enable_session_management {
             domain
                 .tx_variations
-                .push(TransactionVariation::session_establishment_variation(DEFAULT_TEMPLATE_MAX_GAS_SPEND));
+                .push(TransactionVariation::session_establishment_variation(
+                    DEFAULT_TEMPLATE_MAX_GAS_SPEND,
+                ));
             domain
                 .tx_variations
-                .push(TransactionVariation::session_revocation_variation(DEFAULT_TEMPLATE_MAX_GAS_SPEND));
+                .push(TransactionVariation::session_revocation_variation(
+                    DEFAULT_TEMPLATE_MAX_GAS_SPEND,
+                ));
         }
         domain
             .tx_variations
-            .push(TransactionVariation::intent_transfer_variation(DEFAULT_TEMPLATE_MAX_GAS_SPEND));
+            .push(TransactionVariation::intent_transfer_variation(
+                DEFAULT_TEMPLATE_MAX_GAS_SPEND,
+            ));
     }
 
     Ok(config)

--- a/services/paymaster/src/config.rs
+++ b/services/paymaster/src/config.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use config::File;
 use serde::Deserialize;
 
-use crate::{constraint::TransactionVariation, constraint_templates::DEFAULT_TEMPLATE_MAX_GAS_SPEND};
+use crate::constraint::TransactionVariation;
 
 fn default_true() -> bool {
     true
@@ -31,6 +31,8 @@ pub struct Config {
     pub listen_address: String,
     pub domains: Vec<Domain>,
 }
+
+pub const DEFAULT_TEMPLATE_MAX_GAS_SPEND: u64 = 100_000;
 
 pub fn load_config(config_path: &str) -> Result<Config> {
     let mut config: Config = config::Config::builder()

--- a/services/paymaster/src/config.rs
+++ b/services/paymaster/src/config.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use config::File;
 use serde::Deserialize;
 
-use crate::constraint::TransactionVariation;
+use crate::{constraint::TransactionVariation, constraint_templates::DEFAULT_TEMPLATE_MAX_GAS_SPEND};
 
 fn default_true() -> bool {
     true
@@ -42,14 +42,14 @@ pub fn load_config(config_path: &str) -> Result<Config> {
         if domain.enable_session_management {
             domain
                 .tx_variations
-                .push(TransactionVariation::session_establishment_variation());
+                .push(TransactionVariation::session_establishment_variation(DEFAULT_TEMPLATE_MAX_GAS_SPEND));
             domain
                 .tx_variations
-                .push(TransactionVariation::session_revocation_variation());
+                .push(TransactionVariation::session_revocation_variation(DEFAULT_TEMPLATE_MAX_GAS_SPEND));
         }
         domain
             .tx_variations
-            .push(TransactionVariation::intent_transfer_variation());
+            .push(TransactionVariation::intent_transfer_variation(DEFAULT_TEMPLATE_MAX_GAS_SPEND));
     }
 
     Ok(config)

--- a/services/paymaster/src/constraint_templates.rs
+++ b/services/paymaster/src/constraint_templates.rs
@@ -183,9 +183,11 @@ impl InstructionConstraint {
     }
 }
 
+pub const DEFAULT_TEMPLATE_MAX_GAS_SPEND: u64 = 100_000;
+
 impl TransactionVariation {
     /// The template for the transaction variation that establishes a session.
-    pub fn session_establishment_variation() -> TransactionVariation {
+    pub fn session_establishment_variation(max_gas_spend: u64) -> TransactionVariation {
         TransactionVariation::V1(VariationOrderedInstructionConstraints {
             name: "Session Establishment".to_string(),
             instructions: vec![
@@ -197,21 +199,21 @@ impl TransactionVariation {
                 InstructionConstraint::intent_instruction_constraint(),
                 InstructionConstraint::start_session_instruction_constraint(),
             ],
-            max_gas_spend: 100_000,
+            max_gas_spend,
         })
     }
 
     /// The template for the transaction variation that revokes a session.
-    pub fn session_revocation_variation() -> TransactionVariation {
+    pub fn session_revocation_variation(max_gas_spend: u64) -> TransactionVariation {
         TransactionVariation::V1(VariationOrderedInstructionConstraints {
             name: "Session Revocation".to_string(),
             instructions: vec![InstructionConstraint::revoke_session_instruction_constraint()],
-            max_gas_spend: 100_000,
+            max_gas_spend,
         })
     }
 
     /// The template for the transaction variation that conducts intent transfers.
-    pub fn intent_transfer_variation() -> TransactionVariation {
+    pub fn intent_transfer_variation(max_gas_spend: u64) -> TransactionVariation {
         TransactionVariation::V1(VariationOrderedInstructionConstraints {
             name: "Intent Transfer".to_string(),
             instructions: vec![
@@ -219,7 +221,7 @@ impl TransactionVariation {
                 InstructionConstraint::intent_instruction_constraint(),
                 InstructionConstraint::intent_transfer_instruction_constraint(),
             ],
-            max_gas_spend: 100_000,
+            max_gas_spend,
         })
     }
 }

--- a/services/paymaster/src/constraint_templates.rs
+++ b/services/paymaster/src/constraint_templates.rs
@@ -183,8 +183,6 @@ impl InstructionConstraint {
     }
 }
 
-pub const DEFAULT_TEMPLATE_MAX_GAS_SPEND: u64 = 100_000;
-
 impl TransactionVariation {
     /// The template for the transaction variation that establishes a session.
     pub fn session_establishment_variation(max_gas_spend: u64) -> TransactionVariation {


### PR DESCRIPTION
This PR makes the `max_gas_spend` for the template constraints an argument rather than hardcoding it to a constant. This value can be configured in the future.