### PR TITLE
chore: add a changeset to rev the idl package

### DIFF
--- a/.changeset/thin-meals-argue.md
+++ b/.changeset/thin-meals-argue.md
@@ -1,0 +1,5 @@
+---
+"@fogo/sessions-idls": patch
+---
+
+Add V3 message format to idl


### PR DESCRIPTION
When we added the v3 message format, we never revved the idl, but we did rev the ts sdk which builds messages.  As a result, messages are getting built requesting the v3 format, but the resulting accounts can't be serialized properly.

This is a tricky bug because it only shows up for package consumers -- testing locally in the monorepo will always work correctly.  We should consider adding some way to detect idl changes and avoid this happening again.