### PR TITLE
update dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,10 @@ RUN --mount=type=cache,target=./target/ cp -r ./target/release ./output
 
 FROM debian:bookworm-20250630
 
+RUN apt-get update && apt-get install -y \
+    libssl3 \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy artifacts from other images
 COPY --from=build /src/output/fogo-paymaster /usr/local/bin/


### PR DESCRIPTION
#181 introduced version `0.12.23` of `reqwest` with several TLS-dependent deps. This causes the build on Docker to fail without OpenSSL3 explicitly installed. This PR handles installation of OpenSSL3 in the docker build.