### PR TITLE
fix: widget symbol metadata schema

### DIFF
--- a/packages/sessions-sdk-react/src/get-metadata.ts
+++ b/packages/sessions-sdk-react/src/get-metadata.ts
@@ -13,7 +13,7 @@ const metadataSchema = z.record(
   z.string(),
   z.object({
     name: z.string(),
-    symbol: z.string(),
+    symbol: z.string().optional(),
     image: z.string(),
   }),
 );


### PR DESCRIPTION
fixes this case
```
 "32642h1KPNtsku5DEUA9aRUj1Cc3EdCodzZwFoDtNqQW": {
    "name": "dino 12",
    "symbol": null,
    "image": "https://arweave.net/jkf7OFNz9MFi2Tz2BkYleP5nAzGaeHWbD6NB_cqly_I",
    "description": "generative Art NFT"
  }
```