### PR TITLE
fix: fix paymaster prop not being optional

### DIFF
--- a/.changeset/public-dingos-behave.md
+++ b/.changeset/public-dingos-behave.md
@@ -1,0 +1,5 @@
+---
+"@fogo/sessions-sdk-react": patch
+---
+
+Mark paymaster prop of FogoSessionProvider as optional

--- a/packages/sessions-sdk-react/src/components/session-provider.tsx
+++ b/packages/sessions-sdk-react/src/components/session-provider.tsx
@@ -91,7 +91,7 @@ type Props = ConstrainedOmit<
   privacyPolicyUrl?: string | undefined;
 } & (
     | {
-        paymaster: ComponentProps<typeof SessionProvider>["paymaster"];
+        paymaster?: ComponentProps<typeof SessionProvider>["paymaster"];
         sendToPaymaster?: undefined;
         sponsor?: undefined;
       }


### PR DESCRIPTION
This commit fixes an issue where in #234 , I did not properly mark the `paymaster` prop of the `<FogoSessionProvider>` as optional.  As a result consumers were required to define a `paymaster` prop unnecessarily.