### PR TITLE
feat: paymaster startup log

### DIFF
--- a/services/paymaster/src/api.rs
+++ b/services/paymaster/src/api.rs
@@ -522,5 +522,6 @@ pub async fn run_server(
             rpc_sub,
         }));
     let listener = tokio::net::TcpListener::bind(listen_address).await.unwrap();
+    tracing::info!("Starting paymaster service...");
     axum::serve(listener, app).await.unwrap();
 }


### PR DESCRIPTION
This PR adds a startup log to begin emitting logs for the paymaster service.