### PR TITLE
fix: use custom groupBy

### DIFF
--- a/.changeset/afraid-buckets-spend.md
+++ b/.changeset/afraid-buckets-spend.md
@@ -1,0 +1,5 @@
+---
+"@fogo/sessions-sdk-react": patch
+---
+
+Use custom groupBy rather than using Object.groupBy

--- a/packages/sessions-sdk-react/src/components/sign-in-modal.tsx
+++ b/packages/sessions-sdk-react/src/components/sign-in-modal.tsx
@@ -138,13 +138,11 @@ const WalletsPage = ({
   const [moreOptionsOpen, setMoreOptionsOpen] = useState(false);
 
   const { otherWallets, installedWallets } = useMemo(() => {
-    const { otherWallets, installedWallets } = Object.groupBy(
-      wallets,
-      (wallet) =>
-        wallet.readyState === WalletReadyState.Installed ||
-        wallet.readyState === WalletReadyState.Loadable
-          ? "installedWallets"
-          : "otherWallets",
+    const { otherWallets, installedWallets } = groupBy(wallets, (wallet) =>
+      wallet.readyState === WalletReadyState.Installed ||
+      wallet.readyState === WalletReadyState.Loadable
+        ? "installedWallets"
+        : "otherWallets",
     );
     return {
       otherWallets: otherWallets ?? [],
@@ -315,3 +313,19 @@ const Page = ({
     {children}
   </>
 );
+
+// Object.groupBy is not supported in iOS 14.  We don't really need many
+// polyfills usually and this isn't used in a hot path, so rather setting up a
+// polyfilling library let's just use a manual implementation.
+const groupBy = <T, U extends string>(items: T[], match: (value: T) => U) => {
+  const result: Partial<Record<U, T[]>> = {};
+  for (const item of items) {
+    const matchResult = match(item);
+    if (result[matchResult]) {
+      result[matchResult].push(item);
+    } else {
+      result[matchResult] = [item];
+    }
+  }
+  return result;
+};


### PR DESCRIPTION
Apparently `Object.groupBy` still is not as widely supported as we think, and is in particular not supported on iPhone 14 on any browser.  We don't really have a lot of polyfills that we usually need and this isn't a hot path, so rather than worrying with a proper polyfill, this commit just adds a manual `groupBy` implementation.