### PR TITLE
release: paymaster-tx-validator 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1583,7 +1583,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fogo-paymaster"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/services/paymaster/Cargo.toml
+++ b/services/paymaster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fogo-paymaster"
-version = "0.2.0"
+version = "0.3.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Fogo paymaster service and transaction validator CLI"


### PR DESCRIPTION
I'd like to release this so users of the tool don't have to provide the old fields like mnemonic etc...
