### PR TITLE
feat: add callback to open session panel on bridge in page

### DIFF
--- a/apps/sessions-demo/src/components/Home/demo.tsx
+++ b/apps/sessions-demo/src/components/Home/demo.tsx
@@ -56,6 +56,13 @@ export const Demo = ({ faucetAvailable }: { faucetAvailable: boolean }) => {
               amount={0.5}
               mint={NATIVE_MINT}
             />
+            <Button
+              onPress={() => {
+                sessionState.showBridgeIn();
+              }}
+            >
+              Bridge In
+            </Button>
           </div>
         )}
       </section>

--- a/packages/sessions-sdk-react/src/components/session-button.tsx
+++ b/packages/sessions-sdk-react/src/components/session-button.tsx
@@ -27,7 +27,7 @@ type Props = {
 };
 
 export const SessionButton = ({ requestedLimits, compact }: Props) => {
-  const { onStartSessionInit } = useSessionContext();
+  const { onStartSessionInit, showBridgeIn } = useSessionContext();
   const sessionState = useSession();
   const prevSessionState = useRef(sessionState);
   const [sessionPanelOpen, setSessionPanelOpen] = useState(false);
@@ -96,6 +96,12 @@ export const SessionButton = ({ requestedLimits, compact }: Props) => {
       prevSessionState.current = sessionState;
     }
   }, [sessionState]);
+
+  useEffect(() => {
+    if (showBridgeIn) {
+      setSessionPanelOpen(true);
+    }
+  }, [showBridgeIn]);
 
   return (
     <>

--- a/packages/sessions-sdk-react/src/components/session-panel.tsx
+++ b/packages/sessions-sdk-react/src/components/session-panel.tsx
@@ -5,7 +5,7 @@ import { PublicKey } from "@solana/web3.js";
 import clsx from "clsx";
 import { motion } from "motion/react";
 import type { ComponentProps } from "react";
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { Tabs, TabList, Tab, TabPanel, Heading } from "react-aria-components";
 
 import type {
@@ -33,10 +33,18 @@ type Props = Omit<ComponentProps<"div">, "children"> & {
 };
 
 export const SessionPanel = ({ onClose, className, ...props }: Props) => {
-  const { sessionState, whitelistedTokens } = useSessionContext();
+  const { sessionState, whitelistedTokens, showBridgeIn, setShowBridgeIn } =
+    useSessionContext();
   const [currentScreen, setCurrentScreen] = useState<TokenScreen>(
     TokenScreen.Wallet(),
   );
+
+  useEffect(() => {
+    if (showBridgeIn) {
+      setCurrentScreen(TokenScreen.Deposit());
+      setShowBridgeIn(false);
+    }
+  }, [showBridgeIn, setShowBridgeIn]);
 
   return (
     <div className={clsx(styles.sessionPanel, className)} {...props}>

--- a/packages/sessions-sdk-react/src/hooks/use-session.ts
+++ b/packages/sessions-sdk-react/src/hooks/use-session.ts
@@ -6,6 +6,7 @@ import type {
 } from "@fogo/sessions-sdk";
 import type { Rpc, SolanaRpcApi } from "@solana/kit";
 import type { Connection, PublicKey } from "@solana/web3.js";
+import type { Dispatch, SetStateAction } from "react";
 import { createContext, use } from "react";
 
 import type { SessionState } from "../session-state.js";
@@ -24,6 +25,8 @@ export const SessionContext = createContext<
         | (() => Promise<boolean> | boolean)
         | (() => Promise<void> | void)
         | undefined;
+      showBridgeIn: boolean;
+      setShowBridgeIn: Dispatch<SetStateAction<boolean>>;
     }
   | undefined
 >(undefined);

--- a/packages/sessions-sdk-react/src/session-state.ts
+++ b/packages/sessions-sdk-react/src/session-state.ts
@@ -25,6 +25,7 @@ export type EstablishedOptions = Omit<Session, "sessionInfo"> & {
   createLogInToken: () => Promise<string>;
   isLimited: boolean;
   endSession: () => void;
+  showBridgeIn: () => void;
   updateSession: (
     prevState: StateType,
     duration: number,


### PR DESCRIPTION
We want some apps to have a way to have a button on the page which will open the session widget directly onto the page to bridge USDC in from Solana.

This is a bit of a hacky way of doing it, but it's the least-invasive way to add the functionality with a decent client API.  I think this is an OK tradeoff since I doubt this feature will be kept around long after the initial mainnet launch.

NOTE: there's no need for a changeset since this will be part of the bridging in/out feature which already has a changeset.