### PR TITLE
fix: remove wh program check from intent transfer

### DIFF
--- a/programs/intent-transfer/src/bridge/cpi/ntt_manager.rs
+++ b/programs/intent-transfer/src/bridge/cpi/ntt_manager.rs
@@ -2,9 +2,6 @@ use anchor_lang::prelude::*;
 use anchor_lang::solana_program;
 use anchor_lang::solana_program::instruction::Instruction;
 
-pub const WORMHOLE_PROGRAM_ID: Pubkey =
-    Pubkey::from_str_const("BhnQyKoQQgpuRTRo6D8Emz93PvXCYfVgHhnrR4T3qhw4");
-
 pub const TRANSFER_BURN_DISCRIMINATOR: [u8; 8] = [75, 144, 26, 232, 39, 12, 75, 222];
 pub const RELEASE_WORMHOLE_OUTBOUND_DISCRIMINATOR: [u8; 8] = [202, 87, 51, 173, 142, 160, 188, 204];
 pub const SESSION_AUTHORITY_SEED: &[u8] = b"session_authority";

--- a/programs/intent-transfer/src/bridge/processor/bridge_ntt_tokens.rs
+++ b/programs/intent-transfer/src/bridge/processor/bridge_ntt_tokens.rs
@@ -1,7 +1,7 @@
 use crate::{
     bridge::{
         config::ntt_config::{verify_ntt_manager, ExpectedNttConfig, EXPECTED_NTT_CONFIG_SEED},
-        cpi::{self, ntt_manager::WORMHOLE_PROGRAM_ID},
+        cpi,
         message::{convert_chain_id_to_wormhole, BridgeMessage, NttMessage},
     },
     error::IntentTransferError,
@@ -77,8 +77,7 @@ pub struct Ntt<'info> {
     #[account(mut)]
     pub wormhole_sequence: UncheckedAccount<'info>,
 
-    /// CHECK: address is checked, but also verified in NTT manager program
-    #[account(address = WORMHOLE_PROGRAM_ID)]
+    /// CHECK: address is checked in NTT manager program
     pub wormhole_program: UncheckedAccount<'info>,
 
     /// CHECK: address is checked

--- a/programs/intent-transfer/tests/bridge_ntt_tokens.rs
+++ b/programs/intent-transfer/tests/bridge_ntt_tokens.rs
@@ -12,10 +12,7 @@ use spl_token::solana_program::keccak;
 
 use intent_transfer::{
     bridge::config::ntt_config::ExpectedNttConfig,
-    bridge::cpi::{
-        ntt_manager::WORMHOLE_PROGRAM_ID,
-        ntt_with_executor::{EXECUTOR_PROGRAM_ID, NTT_WITH_EXECUTOR_PROGRAM_ID},
-    },
+    bridge::cpi::ntt_with_executor::{EXECUTOR_PROGRAM_ID, NTT_WITH_EXECUTOR_PROGRAM_ID},
     bridge::message::convert_chain_id_to_wormhole,
     bridge::processor::bridge_ntt_tokens::BridgeNttTokensArgs,
 };
@@ -274,7 +271,7 @@ fn test_bridge_ntt_tokens_with_mock_wh() {
                 wormhole_bridge: wormhole_bridge.pubkey(),
                 wormhole_fee_collector: wormhole_fee_collector.pubkey(),
                 wormhole_sequence: wormhole_sequence.pubkey(),
-                wormhole_program: WORMHOLE_PROGRAM_ID,
+                wormhole_program: Pubkey::new_unique(), // Mock NTT manager will not check address
                 ntt_with_executor_program: NTT_WITH_EXECUTOR_PROGRAM_ID,
                 executor_program: EXECUTOR_PROGRAM_ID,
                 ntt_peer: ntt_peer.pubkey(),


### PR DESCRIPTION
The WH program ID is checked as part of the NTT manager contract call in its anchor constraints. So it is unnecessary to specify here.