### PR TITLE
chore: remove ata creation for intrachain transfers

### DIFF
--- a/packages/sessions-sdk-ts/src/index.ts
+++ b/packages/sessions-sdk-ts/src/index.ts
@@ -829,10 +829,6 @@ export const sendTransfer = async (options: SendTransferOptions) => {
     options.mint,
     options.walletPublicKey,
   );
-  const destinationAta = getAssociatedTokenAddressSync(
-    options.mint,
-    options.recipient,
-  );
   const program = new IntentTransferProgram(
     new AnchorProvider(options.context.connection, {} as Wallet, {}),
   );
@@ -843,12 +839,6 @@ export const sendTransfer = async (options: SendTransferOptions) => {
   const symbol = metadata?.symbol ?? undefined;
 
   return options.context.sendTransaction(undefined, [
-    createAssociatedTokenAccountIdempotentInstruction(
-      options.context.payer,
-      destinationAta,
-      options.recipient,
-      options.mint,
-    ),
     await buildTransferIntentInstruction(
       program,
       options,


### PR DESCRIPTION
destination ATA is now `init_if_needed`