### PR TITLE
fix: add network as a cache key for cached data

### DIFF
--- a/.changeset/sweet-jeans-carry.md
+++ b/.changeset/sweet-jeans-carry.md
@@ -1,0 +1,6 @@
+---
+"@fogo/sessions-sdk-react": patch
+"@fogo/sessions-sdk-web": patch
+---
+
+Add network to cache keys

--- a/packages/sessions-sdk-react/src/components/deposit-page.tsx
+++ b/packages/sessions-sdk-react/src/components/deposit-page.tsx
@@ -30,7 +30,7 @@ type Props = {
 export const DepositPage = ({ onPressBack, ...props }: Props) => {
   const { getSessionContext, network } = useSessionContext();
   const balance = useData(
-    ["solanaUsdcBalance"],
+    ["solanaUsdcBalance", network, props.sessionState.walletPublicKey],
     async () => {
       const { getSolanaConnection } = await getSessionContext();
       const connection = await getSolanaConnection();

--- a/packages/sessions-sdk-react/src/hooks/use-faucet.ts
+++ b/packages/sessions-sdk-react/src/hooks/use-faucet.ts
@@ -2,11 +2,13 @@ import { useMemo, useCallback } from "react";
 import { mutate } from "swr";
 
 import type { EstablishedSessionState } from "../session-state.js";
+import { useSessionContext } from "./use-session.js";
 import { getCacheKey } from "./use-token-account-data.js";
 
 const FAUCET_URL = "https://gas.zip/faucet/fogo";
 
 export const useFaucet = (sessionState: EstablishedSessionState) => {
+  const { network } = useSessionContext();
   const faucetUrl = useMemo(() => {
     const url = new URL(FAUCET_URL);
     url.searchParams.set("address", sessionState.walletPublicKey.toBase58());
@@ -23,7 +25,7 @@ export const useFaucet = (sessionState: EstablishedSessionState) => {
       const interval = setInterval(() => {
         if (windowRef.closed) {
           clearInterval(interval);
-          mutate(getCacheKey(sessionState.walletPublicKey)).catch(
+          mutate(getCacheKey(network, sessionState.walletPublicKey)).catch(
             (error: unknown) => {
               // eslint-disable-next-line no-console
               console.error("Failed to update token account data", error);
@@ -32,7 +34,7 @@ export const useFaucet = (sessionState: EstablishedSessionState) => {
         }
       }, 100);
     }
-  }, [sessionState, faucetUrl]);
+  }, [sessionState, faucetUrl, network]);
 
   return useMemo(() => ({ showFaucet, faucetUrl }), [showFaucet, faucetUrl]);
 };

--- a/packages/sessions-sdk-react/src/hooks/use-token-account-data.ts
+++ b/packages/sessions-sdk-react/src/hooks/use-token-account-data.ts
@@ -1,3 +1,4 @@
+import type { Network } from "@fogo/sessions-sdk";
 import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { Connection, PublicKey } from "@solana/web3.js";
 import { useCallback } from "react";
@@ -6,26 +7,28 @@ import { z } from "zod";
 import { getMetadata } from "../get-metadata.js";
 import type { EstablishedSessionState } from "../session-state.js";
 import { useData } from "./use-data.js";
-import { useConnection } from "./use-session.js";
+import { useConnection, useSessionContext } from "./use-session.js";
 
 export { StateType } from "./use-data.js";
 
 export const useTokenAccountData = (sessionState: EstablishedSessionState) => {
   const connection = useConnection();
+  const { network } = useSessionContext();
   const getTokenAccountData = useCallback(
     () => getTokenAccounts(connection, sessionState),
     [connection, sessionState],
   );
 
   return useData(
-    getCacheKey(sessionState.walletPublicKey),
+    getCacheKey(network, sessionState.walletPublicKey),
     getTokenAccountData,
     {},
   );
 };
 
-export const getCacheKey = (walletPublicKey: PublicKey) => [
+export const getCacheKey = (network: Network, walletPublicKey: PublicKey) => [
   "tokenAccountData",
+  network,
   walletPublicKey.toBase58(),
 ];
 

--- a/packages/sessions-sdk-react/src/hooks/use-token-metadata.ts
+++ b/packages/sessions-sdk-react/src/hooks/use-token-metadata.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect } from "react";
 
 import { getMetadata } from "../get-metadata.js";
 import { StateType, useData } from "./use-data.js";
-import { useConnection } from "./use-session.js";
+import { useConnection, useSessionContext } from "./use-session.js";
 
 export { StateType } from "./use-data.js";
 
@@ -12,16 +12,21 @@ export type Metadata = Awaited<ReturnType<typeof getTokenMetadata>>;
 
 export const useTokenMetadata = (mint: PublicKey) => {
   const connection = useConnection();
+  const { network } = useSessionContext();
   const getMetadata = useCallback(
     async () => getTokenMetadata(connection, mint),
     [mint, connection],
   );
-  const data = useData(["tokenMetadata", mint.toBase58()], getMetadata, {
-    revalidateIfStale: false,
-    revalidateOnFocus: false,
-    revalidateOnMount: false,
-    revalidateOnReconnect: false,
-  });
+  const data = useData(
+    ["tokenMetadata", network, mint.toBase58()],
+    getMetadata,
+    {
+      revalidateIfStale: false,
+      revalidateOnFocus: false,
+      revalidateOnMount: false,
+      revalidateOnReconnect: false,
+    },
+  );
 
   useEffect(() => {
     if (data.type === StateType.NotLoaded) {


### PR DESCRIPTION
Before this change, we did not have the network as a cache key for data cached with `useData`, or for the session itself.  As a result, when building an app with a selector to change networks, when changing networks:

1. Stale data would be shown in the widget for the wallet on the prior network
2. The session key would be erased on each network switch as the key would be seen as invalid on the new network

As of this change, we now segregate the caches between mainnet & testnet, so switching between networks is much smoother.

We also modify the init hook so that we re-check the cached connection when the network changes, rather than only on app startup.