### PR TITLE
feat: use centralized paymaster for bridging & transfers

### DIFF
--- a/.changeset/four-monkeys-tie.md
+++ b/.changeset/four-monkeys-tie.md
@@ -1,0 +1,6 @@
+---
+"@fogo/sessions-sdk-react": patch
+"@fogo/sessions-sdk": patch
+---
+
+Use central paymaster for transfers & bridging

--- a/packages/sessions-sdk-react/src/components/session-provider.tsx
+++ b/packages/sessions-sdk-react/src/components/session-provider.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import type {
+  SendTransactionOptions,
   Network,
   Session,
   SessionContext as SessionExecutionContext,
+  TransactionOrInstructions,
 } from "@fogo/sessions-sdk";
 import {
   establishSession as establishSessionImpl,
@@ -343,10 +345,11 @@ const useSessionState = ({
   const sendTransaction = useCallback(
     async (
       session: Session,
-      instructions: Parameters<EstablishedOptions["sendTransaction"]>[0],
       establishedOptions: EstablishedOptions,
+      instructions: TransactionOrInstructions,
+      options?: SendTransactionOptions,
     ) => {
-      const result = await session.sendTransaction(instructions);
+      const result = await session.sendTransaction(instructions, options);
       if (result.type === TransactionResultType.Failed) {
         const parsedError = instructionErrorCustomSchema.safeParse(
           result.error,
@@ -471,8 +474,8 @@ const useSessionState = ({
           onEndSession();
         },
         payer: session.payer,
-        sendTransaction: (instructions) =>
-          sendTransaction(session, instructions, establishedOptions),
+        sendTransaction: (instructions, options) =>
+          sendTransaction(session, establishedOptions, instructions, options),
         sessionKey: session.sessionKey,
         isLimited:
           session.sessionInfo.authorizedTokens === AuthorizedTokens.Specific,

--- a/packages/sessions-sdk-ts/src/connection.ts
+++ b/packages/sessions-sdk-ts/src/connection.ts
@@ -7,8 +7,9 @@ import {
 import type {
   Transaction,
   Instruction,
-  Blockhash,
   TransactionWithLifetime,
+  Rpc,
+  GetLatestBlockhashApi,
 } from "@solana/kit";
 import {
   createSolanaRpc,
@@ -96,6 +97,7 @@ export const createSessionConnection = (
   const rpc = createSolanaRpc(rpcUrl);
   const connection = new Web3Connection(rpcUrl, "confirmed");
   const addressLookupTableCache = new Map<string, AddressLookupTableAccount>();
+  const sponsorCache = new Map<string, PublicKey>();
 
   return {
     rpc,
@@ -104,31 +106,29 @@ export const createSessionConnection = (
     getSolanaConnection: createSolanaConnectionGetter(options.network),
     sendToPaymaster: async (
       domain: string,
-      sponsor: PublicKey,
       sessionKey: CryptoKeyPair | undefined,
-      instructions:
-        | (TransactionInstruction | Instruction)[]
-        | VersionedTransaction
-        | (Transaction & TransactionWithLifetime),
-      extraConfig?: {
-        addressLookupTable?: string | undefined;
-        extraSigners?: (CryptoKeyPair | Keypair)[] | undefined;
-      },
-    ) => {
-      const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
-      const transaction = await buildTransaction(
-        connection,
-        latestBlockhash,
+      instructions: TransactionOrInstructions,
+      extraConfig?: SendTransactionOptions,
+    ) =>
+      sendToPaymaster(
+        { ...options, rpc, connection, addressLookupTableCache, sponsorCache },
+        domain,
         sessionKey,
-        sponsor,
         instructions,
-        addressLookupTableCache,
         extraConfig,
-      );
-      return sendToPaymaster(options, domain, transaction);
-    },
-    getSponsor: (domain: string) => getSponsor(options, domain),
+      ),
+    getSponsor: (domain: string) => getSponsor(options, sponsorCache, domain),
   };
+};
+
+export type TransactionOrInstructions =
+  | (TransactionInstruction | Instruction)[]
+  | VersionedTransaction
+  | (Transaction & TransactionWithLifetime);
+
+export type SendTransactionOptions = {
+  addressLookupTable?: string | undefined;
+  extraSigners?: (CryptoKeyPair | Keypair)[] | undefined;
 };
 
 export type Connection = ReturnType<typeof createSessionConnection>;
@@ -157,14 +157,42 @@ const NETWORK_TO_QUERY_PARAM = {
 };
 
 const sendToPaymaster = async (
-  options: Parameters<typeof createSessionConnection>[0],
+  connection: Pick<
+    Parameters<typeof createSessionConnection>[0],
+    "paymaster" | "network" | "sponsor" | "sendToPaymaster"
+  > & {
+    rpc: Rpc<GetLatestBlockhashApi>;
+    connection: Web3Connection;
+    addressLookupTableCache: Map<string, AddressLookupTableAccount>;
+    sponsorCache: Map<string, PublicKey>;
+  },
   domain: string,
-  transaction: Transaction,
+  sessionKey: CryptoKeyPair | undefined,
+  instructions:
+    | (TransactionInstruction | Instruction)[]
+    | VersionedTransaction
+    | (Transaction & TransactionWithLifetime),
+  extraConfig?: {
+    addressLookupTable?: string | undefined;
+    extraSigners?: (CryptoKeyPair | Keypair)[] | undefined;
+  },
 ): Promise<TransactionResult> => {
-  if (options.sendToPaymaster === undefined) {
+  const signerKeys = await getSignerKeys(sessionKey, extraConfig?.extraSigners);
+
+  const transaction = Array.isArray(instructions)
+    ? await buildTransaction(
+        connection,
+        domain,
+        signerKeys,
+        instructions,
+        extraConfig,
+      )
+    : await addSignaturesToExistingTransaction(instructions, signerKeys);
+
+  if (connection.sendToPaymaster === undefined) {
     const url = new URL(
       "/api/sponsor_and_send",
-      options.paymaster ?? DEFAULT_PAYMASTER[options.network],
+      connection.paymaster ?? DEFAULT_PAYMASTER[connection.network],
     );
     url.searchParams.set("domain", domain);
     const response = await fetch(url, {
@@ -183,82 +211,85 @@ const sendToPaymaster = async (
       throw new PaymasterResponseError(response.status, await response.text());
     }
   } else {
-    return options.sendToPaymaster(transaction);
+    return connection.sendToPaymaster(transaction);
   }
 };
 
 const buildTransaction = async (
-  connection: Web3Connection,
-  latestBlockhash: Readonly<{
-    blockhash: Blockhash;
-    lastValidBlockHeight: bigint;
-  }>,
-  sessionKey: CryptoKeyPair | undefined,
-  sponsor: PublicKey,
-  instructions:
-    | (TransactionInstruction | Instruction)[]
-    | VersionedTransaction
-    | (Transaction & TransactionWithLifetime),
-  addressLookupTableCache: Map<string, AddressLookupTableAccount>,
+  connection: Pick<
+    Parameters<typeof createSessionConnection>[0],
+    "paymaster" | "network" | "sponsor"
+  > & {
+    rpc: Rpc<GetLatestBlockhashApi>;
+    connection: Web3Connection;
+    addressLookupTableCache: Map<string, AddressLookupTableAccount>;
+    sponsorCache: Map<string, PublicKey>;
+  },
+  domain: string,
+  signerKeys: CryptoKeyPair[],
+  instructions: (TransactionInstruction | Instruction)[],
   extraConfig?: {
     addressLookupTable?: string | undefined;
     extraSigners?: (CryptoKeyPair | Keypair)[] | undefined;
   },
 ) => {
-  const [signerKeys, addressLookupTable] = await Promise.all([
-    getSignerKeys(sessionKey, extraConfig?.extraSigners),
-    extraConfig?.addressLookupTable === undefined
-      ? Promise.resolve(undefined)
-      : getAddressLookupTable(
-          connection,
-          addressLookupTableCache,
-          extraConfig.addressLookupTable,
-        ),
-  ]);
-
-  if (Array.isArray(instructions)) {
-    const signers = await Promise.all(
-      signerKeys.map((signer) => createSignerFromKeyPair(signer)),
-    );
-
-    return partiallySignTransactionMessageWithSigners(
-      pipe(
-        createTransactionMessage({ version: 0 }),
-        (tx) => setTransactionMessageFeePayer(fromLegacyPublicKey(sponsor), tx),
-        (tx) =>
-          setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-        (tx) =>
-          appendTransactionMessageInstructions(
-            instructions.map((instruction) =>
-              instruction instanceof TransactionInstruction
-                ? fromLegacyTransactionInstruction(instruction)
-                : instruction,
-            ),
-            tx,
+  const [{ value: latestBlockhash }, sponsor, addressLookupTable, signers] =
+    await Promise.all([
+      connection.rpc.getLatestBlockhash().send(),
+      connection.sponsor === undefined
+        ? getSponsor(connection, connection.sponsorCache, domain)
+        : Promise.resolve(connection.sponsor),
+      extraConfig?.addressLookupTable === undefined
+        ? Promise.resolve(undefined)
+        : getAddressLookupTable(
+            connection.connection,
+            connection.addressLookupTableCache,
+            extraConfig.addressLookupTable,
           ),
-        (tx) =>
-          addressLookupTable === undefined
-            ? tx
-            : compressTransactionMessageUsingAddressLookupTables(tx, {
-                [fromLegacyPublicKey(addressLookupTable.key)]:
-                  addressLookupTable.state.addresses.map((address) =>
-                    fromLegacyPublicKey(address),
-                  ),
-              }),
-        (tx) => addSignersToTransactionMessage(signers, tx),
-      ),
-    );
-  } else {
-    const tx =
-      instructions instanceof VersionedTransaction
-        ? (fromVersionedTransaction(instructions) as ReturnType<
-            typeof fromVersionedTransaction
-          > &
-            TransactionWithLifetime) // VersionedTransaction has a lifetime so it's fine to cast it so we can call partiallySignTransaction
-        : instructions;
-    return partiallySignTransaction(signerKeys, tx);
-  }
+      Promise.all(signerKeys.map((signer) => createSignerFromKeyPair(signer))),
+    ]);
+
+  return partiallySignTransactionMessageWithSigners(
+    pipe(
+      createTransactionMessage({ version: 0 }),
+      (tx) => setTransactionMessageFeePayer(fromLegacyPublicKey(sponsor), tx),
+      (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
+      (tx) =>
+        appendTransactionMessageInstructions(
+          instructions.map((instruction) =>
+            instruction instanceof TransactionInstruction
+              ? fromLegacyTransactionInstruction(instruction)
+              : instruction,
+          ),
+          tx,
+        ),
+      (tx) =>
+        addressLookupTable === undefined
+          ? tx
+          : compressTransactionMessageUsingAddressLookupTables(tx, {
+              [fromLegacyPublicKey(addressLookupTable.key)]:
+                addressLookupTable.state.addresses.map((address) =>
+                  fromLegacyPublicKey(address),
+                ),
+            }),
+      (tx) => addSignersToTransactionMessage(signers, tx),
+    ),
+  );
 };
+
+const addSignaturesToExistingTransaction = (
+  transaction: VersionedTransaction | (Transaction & TransactionWithLifetime),
+  signerKeys: CryptoKeyPair[],
+) =>
+  partiallySignTransaction(
+    signerKeys,
+    transaction instanceof VersionedTransaction
+      ? (fromVersionedTransaction(transaction) as ReturnType<
+          typeof fromVersionedTransaction
+        > &
+          TransactionWithLifetime) // VersionedTransaction has a lifetime so it's fine to cast it so we can call partiallySignTransaction
+      : transaction,
+  );
 
 const getSignerKeys = async (
   sessionKey: CryptoKeyPair | undefined,
@@ -299,10 +330,15 @@ const sponsorAndSendResponseSchema = z
   });
 
 const getSponsor = async (
-  options: Parameters<typeof createSessionConnection>[0],
+  options: Pick<
+    Parameters<typeof createSessionConnection>[0],
+    "paymaster" | "network"
+  >,
+  sponsorCache: Map<string, PublicKey>,
   domain: string,
 ) => {
-  if (options.sponsor === undefined) {
+  const value = sponsorCache.get(domain);
+  if (value === undefined) {
     const url = new URL(
       "/api/sponsor_pubkey",
       options.paymaster ?? DEFAULT_PAYMASTER[options.network],
@@ -311,12 +347,14 @@ const getSponsor = async (
     const response = await fetch(url);
 
     if (response.status === 200) {
-      return new PublicKey(z.string().parse(await response.text()));
+      const sponsor = new PublicKey(z.string().parse(await response.text()));
+      sponsorCache.set(domain, sponsor);
+      return sponsor;
     } else {
       throw new PaymasterResponseError(response.status, await response.text());
     }
   } else {
-    return options.sponsor;
+    return value;
   }
 };
 

--- a/packages/sessions-sdk-ts/src/context.ts
+++ b/packages/sessions-sdk-ts/src/context.ts
@@ -3,10 +3,16 @@ import { AnchorProvider } from "@coral-xyz/anchor";
 import { ChainIdProgram } from "@fogo/sessions-idls";
 import { Connection as Web3Connection, Keypair } from "@solana/web3.js";
 
-import type { Connection } from "./connection.js";
+import type {
+  Connection,
+  SendTransactionOptions as SendTransactionBaseOptions,
+  TransactionOrInstructions,
+} from "./connection.js";
 
 // eslint-disable-next-line unicorn/no-typeof-undefined
 const IS_BROWSER = typeof globalThis.window !== "undefined";
+
+export const SESSIONS_INTERNAL_PAYMASTER_DOMAIN = "sessions";
 
 export const createSessionContext = async (options: {
   connection: Connection;
@@ -14,33 +20,40 @@ export const createSessionContext = async (options: {
   domain?: string | undefined;
 }) => {
   const domain = getDomain(options.domain);
-  const sponsor = await options.connection.getSponsor(domain);
+  const [sponsor, internalSponsor] = await Promise.all([
+    options.connection.getSponsor(domain),
+    options.connection.getSponsor(SESSIONS_INTERNAL_PAYMASTER_DOMAIN),
+  ]);
   return {
     chainId: await fetchChainId(options.connection.connection),
     domain: getDomain(options.domain),
     payer: sponsor,
+    internalPayer: internalSponsor,
     getSolanaConnection: options.connection.getSolanaConnection,
     connection: options.connection.connection,
     rpc: options.connection.rpc,
     network: options.connection.network,
     sendTransaction: (
       sessionKey: CryptoKeyPair | undefined,
-      instructions: Parameters<typeof options.connection.sendToPaymaster>[3],
-      extraConfig?: Parameters<typeof options.connection.sendToPaymaster>[4],
+      instructions: TransactionOrInstructions,
+      sendTxOptions?: SendTransactionOptions,
     ) =>
       options.connection.sendToPaymaster(
-        domain,
-        sponsor,
+        sendTxOptions?.paymasterDomain ?? domain,
         sessionKey,
         instructions,
         {
           addressLookupTable:
-            extraConfig?.addressLookupTable ??
+            sendTxOptions?.addressLookupTable ??
             options.defaultAddressLookupTableAddress,
-          extraSigners: extraConfig?.extraSigners,
+          extraSigners: sendTxOptions?.extraSigners,
         },
       ),
   };
+};
+
+export type SendTransactionOptions = SendTransactionBaseOptions & {
+  paymasterDomain?: string | undefined;
 };
 
 export type SessionContext = Awaited<ReturnType<typeof createSessionContext>>;

--- a/packages/sessions-sdk-ts/src/index.ts
+++ b/packages/sessions-sdk-ts/src/index.ts
@@ -53,20 +53,29 @@ import BN from "bn.js";
 import bs58 from "bs58";
 import { z } from "zod";
 
-import type { TransactionResult } from "./connection.js";
+import type {
+  TransactionOrInstructions,
+  TransactionResult,
+} from "./connection.js";
 import { Network, TransactionResultType } from "./connection.js";
-import type { SessionContext } from "./context.js";
+import type { SendTransactionOptions, SessionContext } from "./context.js";
+import { SESSIONS_INTERNAL_PAYMASTER_DOMAIN } from "./context.js";
 import {
   importKey,
   signMessageWithKey,
   verifyMessageWithKey,
 } from "./crypto.js";
 
-export { type SessionContext, createSessionContext } from "./context.js";
+export {
+  type SessionContext,
+  type SendTransactionOptions,
+  createSessionContext,
+} from "./context.js";
 
 export {
   type TransactionResult,
   type Connection,
+  type TransactionOrInstructions,
   Network,
   TransactionResultType,
   createSessionConnection,
@@ -263,8 +272,8 @@ const createSession = async (
         walletPublicKey,
         sessionKey,
         payer: context.payer,
-        sendTransaction: (instructions) =>
-          context.sendTransaction(sessionKey, instructions),
+        sendTransaction: (instructions, extraConfig) =>
+          context.sendTransaction(sessionKey, instructions, extraConfig),
         sessionInfo,
       };
 };
@@ -757,7 +766,8 @@ export type Session = {
   walletPublicKey: PublicKey;
   payer: PublicKey;
   sendTransaction: (
-    instructions: Parameters<SessionContext["sendTransaction"]>[1],
+    instructions: TransactionOrInstructions,
+    extraConfig?: SendTransactionOptions,
   ) => Promise<TransactionResult>;
   sessionInfo: NonNullable<z.infer<typeof sessionInfoSchema>>;
 };
@@ -839,32 +849,39 @@ export const sendTransfer = async (options: SendTransferOptions) => {
   const metadata = await safeFetchMetadata(umi, metadataAddress);
   const symbol = metadata?.symbol ?? undefined;
 
-  return options.context.sendTransaction(undefined, [
-    await buildTransferIntentInstruction(
-      program,
-      options,
-      symbol,
-      options.feeConfig.symbolOrMint,
-      amountToString(options.feeConfig.fee, options.feeConfig.decimals),
-    ),
-    await program.methods
-      .sendTokens()
-      .accounts({
-        destinationOwner: options.recipient,
-        feeMetadata: options.feeConfig.metadata,
-        feeMint: options.feeConfig.mint,
-        feeSource: getAssociatedTokenAddressSync(
-          options.feeConfig.mint,
-          options.walletPublicKey,
-        ),
-        mint: options.mint,
-        source: sourceAta,
-        sponsor: options.context.payer,
-        // eslint-disable-next-line unicorn/no-null
-        metadata: symbol === undefined ? null : new PublicKey(metadataAddress),
-      })
-      .instruction(),
-  ]);
+  return options.context.sendTransaction(
+    undefined,
+    [
+      await buildTransferIntentInstruction(
+        program,
+        options,
+        symbol,
+        options.feeConfig.symbolOrMint,
+        amountToString(options.feeConfig.fee, options.feeConfig.decimals),
+      ),
+      await program.methods
+        .sendTokens()
+        .accounts({
+          destinationOwner: options.recipient,
+          feeMetadata: options.feeConfig.metadata,
+          feeMint: options.feeConfig.mint,
+          feeSource: getAssociatedTokenAddressSync(
+            options.feeConfig.mint,
+            options.walletPublicKey,
+          ),
+          mint: options.mint,
+          source: sourceAta,
+          sponsor: options.context.internalPayer,
+          metadata:
+            // eslint-disable-next-line unicorn/no-null
+            symbol === undefined ? null : new PublicKey(metadataAddress),
+        })
+        .instruction(),
+    ],
+    {
+      paymasterDomain: SESSIONS_INTERNAL_PAYMASTER_DOMAIN,
+    },
+  );
 };
 
 const buildTransferIntentInstruction = async (
@@ -978,7 +995,7 @@ export const bridgeOut = async (options: SendBridgeOutOptions) => {
         signedQuoteBytes: Buffer.from(quote.signedQuote),
       })
       .accounts({
-        sponsor: options.context.payer,
+        sponsor: options.context.internalPayer,
         mint: options.fromToken.mint,
         metadata:
           metadata?.symbol === undefined
@@ -1007,6 +1024,7 @@ export const bridgeOut = async (options: SendBridgeOutOptions) => {
       ...instructions,
     ],
     {
+      paymasterDomain: SESSIONS_INTERNAL_PAYMASTER_DOMAIN,
       extraSigners: [outboxItem],
       addressLookupTable:
         BRIDGING_ADDRESS_LOOKUP_TABLE[options.context.network]?.[


### PR DESCRIPTION
This commit changes bridging & transfers to use a centralized paymaster rather than the app's paymaster.

This required some significant refactoring in the session connection because there were a lot of implicit assumptions that all txns use the same sponsor key and paymaster domain.