### PR TITLE
feat: add tx variation query param support to sdk

### DIFF
--- a/.changeset/open-aliens-retire.md
+++ b/.changeset/open-aliens-retire.md
@@ -1,0 +1,5 @@
+---
+"@fogo/sessions-sdk": patch
+---
+
+Add support for explicitly specifying the tx variation when sending a tx to the paymaster

--- a/packages/sessions-sdk-ts/src/connection.ts
+++ b/packages/sessions-sdk-ts/src/connection.ts
@@ -127,6 +127,7 @@ export type TransactionOrInstructions =
   | (Transaction & TransactionWithLifetime);
 
 export type SendTransactionOptions = {
+  variation?: string | undefined;
   addressLookupTable?: string | undefined;
   extraSigners?: (CryptoKeyPair | Keypair)[] | undefined;
 };
@@ -168,14 +169,8 @@ const sendToPaymaster = async (
   },
   domain: string,
   sessionKey: CryptoKeyPair | undefined,
-  instructions:
-    | (TransactionInstruction | Instruction)[]
-    | VersionedTransaction
-    | (Transaction & TransactionWithLifetime),
-  extraConfig?: {
-    addressLookupTable?: string | undefined;
-    extraSigners?: (CryptoKeyPair | Keypair)[] | undefined;
-  },
+  instructions: TransactionOrInstructions,
+  extraConfig?: SendTransactionOptions,
 ): Promise<TransactionResult> => {
   const signerKeys = await getSignerKeys(sessionKey, extraConfig?.extraSigners);
 
@@ -195,6 +190,9 @@ const sendToPaymaster = async (
       connection.paymaster ?? DEFAULT_PAYMASTER[connection.network],
     );
     url.searchParams.set("domain", domain);
+    if (extraConfig?.variation !== undefined) {
+      url.searchParams.set("variation", extraConfig.variation);
+    }
     const response = await fetch(url, {
       method: "POST",
       headers: {

--- a/packages/sessions-sdk-ts/src/context.ts
+++ b/packages/sessions-sdk-ts/src/context.ts
@@ -43,10 +43,10 @@ export const createSessionContext = async (options: {
         sessionKey,
         instructions,
         {
+          ...sendTxOptions,
           addressLookupTable:
             sendTxOptions?.addressLookupTable ??
             options.defaultAddressLookupTableAddress,
-          extraSigners: sendTxOptions?.extraSigners,
         },
       ),
   };

--- a/packages/sessions-sdk-ts/src/index.ts
+++ b/packages/sessions-sdk-ts/src/index.ts
@@ -158,6 +158,7 @@ const sendSessionEstablishTransaction = async (
     sessionKey,
     instructions,
     {
+      variation: "Session Establishment",
       addressLookupTable:
         sessionEstablishmentLookupTable ??
         SESSION_ESTABLISHMENT_LOOKUP_TABLE_ADDRESS[options.context.network],
@@ -215,9 +216,13 @@ export const revokeSession = async (options: {
         session: options.session.sessionPublicKey,
       })
       .instruction();
-    return options.context.sendTransaction(options.session.sessionKey, [
-      instruction,
-    ]);
+    return options.context.sendTransaction(
+      options.session.sessionKey,
+      [instruction],
+      {
+        variation: "Session Revocation",
+      },
+    );
   } else {
     return;
   }
@@ -858,6 +863,7 @@ export const sendTransfer = async (options: SendTransferOptions) => {
         .instruction(),
     ],
     {
+      variation: "Intent Transfer",
       paymasterDomain: SESSIONS_INTERNAL_PAYMASTER_DOMAIN,
     },
   );
@@ -1003,6 +1009,7 @@ export const bridgeOut = async (options: SendBridgeOutOptions) => {
       ...instructions,
     ],
     {
+      variation: "Intent NTT Bridge",
       paymasterDomain: SESSIONS_INTERNAL_PAYMASTER_DOMAIN,
       extraSigners: [outboxItem],
       addressLookupTable:


### PR DESCRIPTION
This commit adds support for setting the tx variation query param.  This cannot be merged before the paymaster is upgraded to support the param because we have strict query param parsing in the paymaster, so the paymaster returns a 400 if the param is passed before the upgrade.