### PR TITLE
fix: allow scrolling modals

### DIFF
--- a/.changeset/wise-actors-speak.md
+++ b/.changeset/wise-actors-speak.md
@@ -1,0 +1,5 @@
+---
+"@fogo/sessions-sdk-react": patch
+---
+
+Enable modals to scroll

--- a/packages/sessions-sdk-react/src/components/modal-dialog.module.scss
+++ b/packages/sessions-sdk-react/src/components/modal-dialog.module.scss
@@ -5,17 +5,19 @@
     position: fixed;
     top: 0;
     left: 0;
-    width: 100vw;
-    height: var(--visual-viewport-height);
+    height: 100dvh;
+    width: 100dvw;
     background: theme.color("modal-overlay");
     backdrop-filter: blur(8px);
     display: grid;
     justify-content: center;
     align-items: start;
-    padding-top: theme.spacing(40);
     z-index: theme.layer("modal-dialog");
+    overflow: auto;
 
     .modal {
+      margin-top: min(10dvh, theme.spacing(40));
+      margin-bottom: min(10dvh, theme.spacing(40));
       outline: none;
       background-color: theme.color("card");
       padding: theme.spacing(6);
@@ -23,7 +25,7 @@
       border: 1px solid theme.color("widget-border");
       box-shadow: theme.shadow();
       width: theme.spacing(94);
-      max-width: 70dvw;
+      max-width: 90dvw;
 
       .dialog {
         outline: none;


### PR DESCRIPTION
Our modals are usually pretty small and in nearly all cases will fit into the height of any realistic screen.  However, the new disclaimer modal is quite tall, and on sufficiently small screens (i.e. small mobile devices), the bottom of the modal gets cut off.

This commit adds some minor css tweaks to ensure the UX for modals is reasonable at those sizes and that the modal can be scrolled.