### PR TITLE
fix: always use central paymaster for portfolio app

### DIFF
--- a/apps/portfolio/src/config/server.ts
+++ b/apps/portfolio/src/config/server.ts
@@ -24,9 +24,4 @@ export const GOOGLE_ANALYTICS_ID = defaultInProduction(
 export const ENABLE_ACCESSIBILITY_REPORTING =
   !IS_PRODUCTION_SERVER && !process.env.DISABLE_ACCESSIBILITY_REPORTING;
 
-// TODO Replace this domain with https://portfolio.fogo.io after setting up a
-// new paymaster for it
-export const DOMAIN = getEnvOrDefault(
-  "DOMAIN",
-  "https://sessions-example.fogo.io",
-);
+export const DOMAIN = getEnvOrDefault("DOMAIN", "sessions");


### PR DESCRIPTION
Currently the portfolio app has no functionality outside the sessions widget, so it doesn't make sense for it to have it's own paymaster.

I had originally had it pointing to the sessions-example paymaster to get things off the ground, but it's better to just use the central sessions paymaster for this.

If we ever go to add functionality to the portfolio app that does not live in the sessions widget, we can revisit this and spin up a paymaster for the portfolio app specifically.