### PR TITLE
fix: separate wallet signature from extra signers

### DIFF
--- a/.changeset/smooth-pugs-nail.md
+++ b/.changeset/smooth-pugs-nail.md
@@ -1,0 +1,6 @@
+---
+"@fogo/sessions-sdk-react": patch
+"@fogo/sessions-sdk": patch
+---
+
+Silence Phantom warnings

--- a/packages/sessions-sdk-react/src/components/deposit-page.tsx
+++ b/packages/sessions-sdk-react/src/components/deposit-page.tsx
@@ -59,7 +59,7 @@ export const DepositPage = ({ onPressBack, ...props }: Props) => {
         throw error;
       }
     }
-  }, [getSessionContext, props.sessionState.walletPublicKey]);
+  }, [getSessionContext, props.sessionState.walletPublicKey, network]);
   const balance = useData(
     ["solanaUsdcBalance", network, props.sessionState.walletPublicKey],
     getSolanaBalance,

--- a/packages/sessions-sdk-react/src/solana-wallet.ts
+++ b/packages/sessions-sdk-react/src/solana-wallet.ts
@@ -1,6 +1,6 @@
 import type {
   MessageSignerWalletAdapterProps,
-  BaseWalletAdapter,
+  BaseSignerWalletAdapter,
   WalletReadyState,
   WalletError,
 } from "@solana/wallet-adapter-base";
@@ -31,7 +31,7 @@ export type SolanaWalletEventEmitter = {
 };
 
 export type SolanaWallet = MessageSignerWalletAdapterProps &
-  BaseWalletAdapter &
+  BaseSignerWalletAdapter &
   SolanaWalletEventEmitter;
 
 export type SolanaMobileWallet = SolanaMobileWalletAdapter &


### PR DESCRIPTION
I believe this will silence the Phantom warnings that come up when bridging in.