### PR TITLE
fix: fix Solana explorer links

### DIFF
--- a/.changeset/gold-sheep-clap.md
+++ b/.changeset/gold-sheep-clap.md
@@ -1,0 +1,5 @@
+---
+"@fogo/sessions-sdk-react": patch
+---
+
+Fix Solana explorer link

--- a/packages/sessions-sdk-react/src/components/deposit-page.tsx
+++ b/packages/sessions-sdk-react/src/components/deposit-page.tsx
@@ -20,7 +20,7 @@ import { UsdcIcon } from "./usdc-icon.js";
 import { StateType, useData } from "../hooks/use-data.js";
 import { useSessionContext } from "../hooks/use-session.js";
 import { USDC } from "../wormhole-routes.js";
-import { ExplorerLink, SolanaNetwork } from "./explorer-link.js";
+import { ExplorerLink, Chain } from "./explorer-link.js";
 import { FetchError } from "./fetch-error.js";
 
 type Props = {
@@ -201,11 +201,8 @@ const DepositForm = ({
               "Tokens transferred to Fogo successfully!",
               txHash === undefined ? undefined : (
                 <ExplorerLink
-                  network={
-                    network === Network.Mainnet
-                      ? SolanaNetwork.Mainnet
-                      : SolanaNetwork.Devnet
-                  }
+                  network={network}
+                  chain={Chain.Solana}
                   txHash={txHash}
                 />
               ),

--- a/packages/sessions-sdk-react/src/components/explorer-link.tsx
+++ b/packages/sessions-sdk-react/src/components/explorer-link.tsx
@@ -1,45 +1,43 @@
-import { Network as FogoNetwork } from "@fogo/sessions-sdk";
+import { Network } from "@fogo/sessions-sdk";
 import type { ComponentProps } from "react";
 import type { Link as UnstyledLink } from "react-aria-components";
 
 import { Link } from "./link.js";
 
 type Props = ComponentProps<typeof UnstyledLink> & {
-  network: FogoNetwork | SolanaNetwork;
+  network: Network;
+  chain?: Chain;
   txHash: string;
 };
 
 export const ExplorerLink = ({
   children,
   network,
+  chain = Chain.Fogo,
   txHash,
   ...props
 }: Props) => (
-  <Link href={mkLink(network, txHash)} target="_blank" {...props}>
+  <Link href={mkLink(network, chain, txHash)} target="_blank" {...props}>
     {children ?? "Open Explorer"}
   </Link>
 );
 
-export enum SolanaNetwork {
-  Mainnet,
-  Devnet,
+export enum Chain {
+  Solana,
+  Fogo,
 }
 
-const mkLink = (network: FogoNetwork | SolanaNetwork, txHash: string) => {
+const mkLink = (network: Network, chain: Chain, txHash: string) => {
   switch (network) {
-    case FogoNetwork.Mainnet: {
-      return `https://explorer.fogo.io/tx/${txHash}?cluster=mainnet-beta`;
+    case Network.Mainnet: {
+      return chain === Chain.Solana
+        ? `https://solscan.io/tx/${txHash}`
+        : `https://explorer.fogo.io/tx/${txHash}?cluster=mainnet-beta`;
     }
-
-    case FogoNetwork.Testnet: {
-      return `https://fogoscan.com/tx/${txHash}?cluster=testnet`;
-    }
-
-    case SolanaNetwork.Mainnet: {
-      return `https://solscan.io/tx/${txHash}`;
-    }
-    case SolanaNetwork.Devnet: {
-      return `https://solscan.io/tx/${txHash}?cluster=devnet`;
+    case Network.Testnet: {
+      return chain === Chain.Solana
+        ? `https://solscan.io/tx/${txHash}?cluster=devnet`
+        : `https://fogoscan.com/tx/${txHash}?cluster=testnet`;
     }
   }
 };


### PR DESCRIPTION
This commit fixes a bug in the `<ExplorerLink>` component; I had originally coded it to take a prop which could have a value from one of two separate enums and would generate the link text based on which element from which enum it was.  But this doesn't work at runtime because typescript types are structural, not nominal, so enums members are equivalent based on their position in the enum.  In other words:

```ts
enum Foo { Foo1, Foo2 };
enum Bar { Bar1, Bar2 };

const someFn = (val: Foo | Bar) => val === Bar.Bar1;

someFn(Foo.Foo1); // type-checks due to `Foo | Bar` as the argument type, and returns `true` due to structural typing
```

This PR resolves the issue changes the interface so that we specify a `chain` & `network`, rather than having a single prop whose value can come from two separate enums.