### PR TITLE
fix: fix text wrapping issues

### DIFF
--- a/.changeset/fluffy-donkeys-flow.md
+++ b/.changeset/fluffy-donkeys-flow.md
@@ -1,0 +1,5 @@
+---
+"@fogo/sessions-sdk-react": patch
+---
+
+Fix text wrapping issues

--- a/packages/sessions-sdk-react/src/components/deposit-page.module.scss
+++ b/packages/sessions-sdk-react/src/components/deposit-page.module.scss
@@ -34,15 +34,17 @@
         @include theme.text("lg", "medium");
 
         color: theme.color("heading");
-        word-break: break-all;
       }
 
       .amountInWallet {
         @include theme.text("sm");
 
         color: theme.color("paragraph");
-        word-break: break-all;
         height: 1em;
+
+        .amount {
+          word-break: break-all;
+        }
 
         &[data-is-loading] {
           display: inline-block;

--- a/packages/sessions-sdk-react/src/components/deposit-page.tsx
+++ b/packages/sessions-sdk-react/src/components/deposit-page.tsx
@@ -248,8 +248,14 @@ const DepositForm = ({
           className={styles.amountInWallet}
           data-is-loading={props.isLoading ? "" : undefined}
         >
-          {!props.isLoading &&
-            `${props.balances.usdc.uiAmountString ?? "0"} USDC available`}
+          {!props.isLoading && (
+            <>
+              <span className={styles.amount}>
+                {props.balances.usdc.uiAmountString ?? "0"}
+              </span>{" "}
+              USDC available
+            </>
+          )}
         </div>
       </div>
       <TokenAmountInput

--- a/packages/sessions-sdk-react/src/components/send-token-page.module.scss
+++ b/packages/sessions-sdk-react/src/components/send-token-page.module.scss
@@ -35,14 +35,16 @@
         @include theme.text("lg", "medium");
 
         color: theme.color("heading");
-        word-break: break-all;
       }
 
       .amountInWallet {
         @include theme.text("sm");
 
         color: theme.color("paragraph");
-        word-break: break-all;
+
+        .amount {
+          word-break: break-all;
+        }
       }
     }
 

--- a/packages/sessions-sdk-react/src/components/send-token-page.tsx
+++ b/packages/sessions-sdk-react/src/components/send-token-page.tsx
@@ -316,7 +316,10 @@ const SendTokenPageImpl = ({
             Send {tokenName ?? <TruncateKey keyValue={tokenMint} />}
           </h2>
           <div className={styles.amountInWallet}>
-            {amountToString(amountAvailable, decimals)} {symbol} available
+            <span className={styles.amount}>
+              {amountToString(amountAvailable, decimals)}
+            </span>{" "}
+            {symbol} available
           </div>
         </div>
         <TextField

--- a/packages/sessions-sdk-react/src/components/withdraw-page.module.scss
+++ b/packages/sessions-sdk-react/src/components/withdraw-page.module.scss
@@ -34,15 +34,17 @@
         @include theme.text("lg", "medium");
 
         color: theme.color("heading");
-        word-break: break-all;
       }
 
       .amountInWallet {
         @include theme.text("sm");
 
         color: theme.color("paragraph");
-        word-break: break-all;
         height: 1em;
+
+        .amount {
+          word-break: break-all;
+        }
 
         &[data-is-loading] {
           display: inline-block;

--- a/packages/sessions-sdk-react/src/components/withdraw-page.tsx
+++ b/packages/sessions-sdk-react/src/components/withdraw-page.tsx
@@ -239,8 +239,17 @@ const WithdrawFormImpl = (
           className={styles.amountInWallet}
           data-is-loading={props.isLoading ? "" : undefined}
         >
-          {!props.isLoading &&
-            `${amountToString(props.amountAvailable, USDC.decimals).toString()} USDC available`}
+          {!props.isLoading && (
+            <>
+              <span className={styles.amount}>
+                {amountToString(
+                  props.amountAvailable,
+                  USDC.decimals,
+                ).toString()}
+              </span>{" "}
+              USDC available
+            </>
+          )}
         </div>
       </div>
       <TokenAmountInput


### PR DESCRIPTION
This commit fixes some minor text wrapping issues that I'd noticed on small / mobile screen sizes.

Before:

<img width="554" height="1118" alt="screenshot-2025-11-26-113330" src="https://github.com/user-attachments/assets/0e4ad831-9069-4bf4-b15b-799efafe8910" />


After:

<img width="554" height="1118" alt="screenshot-2025-11-26-113333" src="https://github.com/user-attachments/assets/fef5ec86-904d-4eb4-b2d6-51a68a13732e" />

