### PR TITLE
feat: show native balance; add enable native transfers w/ wallet

### DIFF
--- a/.changeset/nice-trains-clap.md
+++ b/.changeset/nice-trains-clap.md
@@ -1,0 +1,6 @@
+---
+"@fogo/sessions-sdk-react": patch
+"@fogo/sessions-sdk": patch
+---
+
+Show native token balance & allow signing transactions with wallet

--- a/apps/sessions-demo/next-env.d.ts
+++ b/apps/sessions-demo/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/sessions-demo/src/components/Home/demo.tsx
+++ b/apps/sessions-demo/src/components/Home/demo.tsx
@@ -20,6 +20,7 @@ import type { Transaction } from "./use-transaction-log";
 import { useTransactionLog } from "./use-transaction-log";
 import { StateType as AsyncStateType } from "../../hooks/use-async";
 import { Button } from "../Button";
+import { useTradeNative } from "./use-trade-native";
 
 export const Demo = ({ faucetAvailable }: { faucetAvailable: boolean }) => {
   const connection = useConnection();
@@ -57,11 +58,16 @@ export const Demo = ({ faucetAvailable }: { faucetAvailable: boolean }) => {
                 />
               </>
             )}
-            <TradeButton
+            <TradeSplButton
               sessionState={sessionState}
               appendTransaction={appendTransaction}
-              amount={0.5}
+              amount={0.1}
               mint={NATIVE_MINT}
+            />
+            <TradeNativeButton
+              sessionState={sessionState}
+              appendTransaction={appendTransaction}
+              amount={0.1}
             />
             <Button
               onPress={() => {
@@ -125,7 +131,7 @@ const AirdropUsdcButton = ({
   );
 };
 
-const TradeButton = ({
+const TradeSplButton = ({
   amount,
   sessionState,
   appendTransaction,
@@ -144,7 +150,28 @@ const TradeButton = ({
   );
   return (
     <Button onClick={execute} isPending={state.type === AsyncStateType.Running}>
-      Trade {amount} FOGO
+      Trade {amount} wFOGO
+    </Button>
+  );
+};
+
+const TradeNativeButton = ({
+  amount,
+  sessionState,
+  appendTransaction,
+}: {
+  amount: number;
+  sessionState: EstablishedSessionState;
+  appendTransaction: (tx: Transaction) => void;
+}) => {
+  const { state, execute } = useTradeNative(
+    sessionState,
+    appendTransaction,
+    amount,
+  );
+  return (
+    <Button onClick={execute} isPending={state.type === AsyncStateType.Running}>
+      Trade {amount} Native FOGO
     </Button>
   );
 };

--- a/apps/sessions-demo/src/components/Home/use-trade-native.ts
+++ b/apps/sessions-demo/src/components/Home/use-trade-native.ts
@@ -1,0 +1,40 @@
+import { TransactionResultType } from "@fogo/sessions-sdk";
+import type { EstablishedSessionState } from "@fogo/sessions-sdk-react";
+import { SystemProgram } from "@solana/web3.js";
+import { useCallback } from "react";
+
+import type { Transaction } from "./use-transaction-log";
+import { useAsync } from "../../hooks/use-async";
+
+const LAMPORTS_PER_SOL = 1_000_000_000;
+
+export const useTradeNative = (
+  sessionState: EstablishedSessionState,
+  appendTransaction: (tx: Transaction) => void,
+  amount: number,
+) => {
+  const doTrade = useCallback(async () => {
+    const result = await sessionState.sendTransaction(
+      [
+        SystemProgram.transfer({
+          fromPubkey: sessionState.walletPublicKey,
+          lamports: BigInt(amount * LAMPORTS_PER_SOL),
+          toPubkey: sessionState.payer,
+        }),
+      ],
+      {
+        preprocessTransaction: sessionState.signTxWithWallet,
+      },
+    );
+
+    appendTransaction({
+      description: "Trade",
+      signature: result.signature,
+      success: result.type === TransactionResultType.Success,
+    });
+
+    return result;
+  }, [sessionState, appendTransaction, amount]);
+
+  return useAsync(doTrade);
+};

--- a/apps/sessions-demo/turbo.json
+++ b/apps/sessions-demo/turbo.json
@@ -13,6 +13,11 @@
       ]
     },
     "start:dev": {
+      "with": [
+        "@fogo/sessions-sdk#start:dev",
+        "@fogo/sessions-sdk-web#start:dev",
+        "@fogo/sessions-sdk-react#start:dev"
+      ],
       "env": [
         "ADDRESS_LOOKUP_TABLE_ADDRESS",
         "RPC",

--- a/packages/sessions-sdk-react/package.json
+++ b/packages/sessions-sdk-react/package.json
@@ -55,6 +55,7 @@
     "@phosphor-icons/react": "catalog:",
     "@react-hookz/web": "catalog:",
     "@solana-mobile/wallet-adapter-mobile": "catalog:",
+    "@solana/compat": "catalog:",
     "@solana/kit": "catalog:",
     "@solana/spl-token": "catalog:",
     "@solana/wallet-adapter-backpack": "catalog:",

--- a/packages/sessions-sdk-react/src/components/token-list.module.scss
+++ b/packages/sessions-sdk-react/src/components/token-list.module.scss
@@ -103,6 +103,19 @@
       }
     }
 
+    &[data-is-native] .mint {
+      @include theme.text("xs", "normal");
+
+      background-color: theme.color("button-base");
+      height: theme.spacing(5);
+      padding-left: theme.spacing(1);
+      padding-right: theme.spacing(1);
+      color: theme.color("muted");
+      display: grid;
+      place-content: center;
+      border-radius: theme.border-radius();
+    }
+
     &[data-is-loading] {
       .nameAndIcon .icon,
       .nameAndIcon .nameAndMint .name,
@@ -174,7 +187,7 @@
       }
     }
 
-    &:not([data-is-button], [data-is-loading]) {
+    &:not([data-is-button], [data-is-loading], [data-is-native]) {
       .amountAndActions {
         position: relative;
         transform: translateX(calc(theme.spacing(15) + 1px));

--- a/packages/sessions-sdk-react/src/session-state.ts
+++ b/packages/sessions-sdk-react/src/session-state.ts
@@ -1,4 +1,5 @@
 import type { Session } from "@fogo/sessions-sdk";
+import type { Transaction } from "@solana/kit";
 import type { PublicKey } from "@solana/web3.js";
 
 import type { SolanaWallet } from "./solana-wallet.js";
@@ -24,6 +25,7 @@ export type EstablishedOptions = Omit<Session, "sessionInfo"> & {
   isLimited: boolean;
   endSession: () => void;
   showBridgeIn: () => void;
+  signTxWithWallet: (transaction: Transaction) => Promise<Transaction>;
   updateSession: (
     prevState: StateType,
     duration: number,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,10 +70,10 @@ catalogs:
       specifier: ^0.5.1
       version: 0.5.1
     '@solana/compat':
-      specifier: ^4.0.0
+      specifier: 4.0.0
       version: 4.0.0
     '@solana/kit':
-      specifier: ^4.0.0
+      specifier: 4.0.0
       version: 4.0.0
     '@solana/spl-token':
       specifier: ^0.4.13
@@ -429,10 +429,10 @@ importers:
         version: 25.1.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@solana-program/token':
         specifier: 'catalog:'
-        version: 0.5.1(@solana/kit@4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+        version: 0.5.1(@solana/kit@4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@solana/kit':
         specifier: 'catalog:'
-        version: 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        version: 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/spl-token':
         specifier: 'catalog:'
         version: 0.4.13(@solana/web3.js@1.98.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
@@ -573,6 +573,9 @@ importers:
       '@solana-mobile/wallet-adapter-mobile':
         specifier: 'catalog:'
         version: 2.2.4(@solana/web3.js@1.98.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.1.8)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10))(react@19.1.1)
+      '@solana/compat':
+        specifier: 'catalog:'
+        version: 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/kit':
         specifier: 'catalog:'
         version: 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
@@ -5399,9 +5402,11 @@ packages:
 
   '@walletconnect/sign-client@2.19.0':
     resolution: {integrity: sha512-+GkuJzPK9SPq+RZgdKHNOvgRagxh/hhYWFHOeSiGh3DyAQofWuFTq4UrN/MPjKOYswSSBKfIa+iqKYsi4t8zLQ==}
+    deprecated: 'Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases'
 
   '@walletconnect/sign-client@2.19.1':
     resolution: {integrity: sha512-OgBHRPo423S02ceN3lAzcZ3MYb1XuLyTTkKqLmKp/icYZCyRzm3/ynqJDKndiBLJ5LTic0y07LiZilnliYqlvw==}
+    deprecated: 'Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases'
 
   '@walletconnect/solana-adapter@0.0.8':
     resolution: {integrity: sha512-Qb7MT8SdkeBldfUCmF+rYW6vL98mxPuT1yAwww5X2vpx7xEPZvFCoAKnyT5fXu0v56rMxhW3MGejnHyyYdDY7Q==}
@@ -5420,9 +5425,11 @@ packages:
 
   '@walletconnect/universal-provider@2.19.0':
     resolution: {integrity: sha512-e9JvadT5F8QwdLmd7qBrmACq04MT7LQEe1m3X2Fzvs3DWo8dzY8QbacnJy4XSv5PCdxMWnua+2EavBk8nrI9QA==}
+    deprecated: 'Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases'
 
   '@walletconnect/universal-provider@2.19.1':
     resolution: {integrity: sha512-4rdLvJ2TGDIieNWW3sZw2MXlX65iHpTuKb5vyvUHQtjIVNLj+7X/09iUAI/poswhtspBK0ytwbH+AIT/nbGpjg==}
+    deprecated: 'Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases'
 
   '@walletconnect/utils@2.19.0':
     resolution: {integrity: sha512-LZ0D8kevknKfrfA0Sq3Hf3PpmM8oWyNfsyWwFR51t//2LBgtN2Amz5xyoDDJcjLibIbKAxpuo/i0JYAQxz+aPA==}
@@ -15430,9 +15437,9 @@ snapshots:
     dependencies:
       '@solana/kit': 2.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
-  '@solana-program/token@0.5.1(@solana/kit@4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
+  '@solana-program/token@0.5.1(@solana/kit@4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
-      '@solana/kit': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/kit': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
   '@solana/accounts@2.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
     dependencies:
@@ -15733,32 +15740,6 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - ws
 
-  '@solana/kit@4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@solana/accounts': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/addresses': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/codecs': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/errors': 4.0.0(typescript@5.8.3)
-      '@solana/functional': 4.0.0(typescript@5.8.3)
-      '@solana/instruction-plans': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/instructions': 4.0.0(typescript@5.8.3)
-      '@solana/keys': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/programs': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/rpc': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/rpc-parsed-types': 4.0.0(typescript@5.8.3)
-      '@solana/rpc-spec-types': 4.0.0(typescript@5.8.3)
-      '@solana/rpc-subscriptions': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/rpc-types': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/signers': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/sysvars': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/transaction-confirmation': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/transaction-messages': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/transactions': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - ws
-
   '@solana/kit@4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/accounts': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
@@ -15947,15 +15928,6 @@ snapshots:
       typescript: 5.8.3
       ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
 
-  '@solana/rpc-subscriptions-channel-websocket@4.0.0(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@solana/errors': 4.0.0(typescript@5.8.3)
-      '@solana/functional': 4.0.0(typescript@5.8.3)
-      '@solana/rpc-subscriptions-spec': 4.0.0(typescript@5.8.3)
-      '@solana/subscribable': 4.0.0(typescript@5.8.3)
-      typescript: 5.8.3
-      ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-
   '@solana/rpc-subscriptions-channel-websocket@4.0.0(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/errors': 4.0.0(typescript@5.8.3)
@@ -15994,24 +15966,6 @@ snapshots:
       '@solana/rpc-transformers': 2.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/rpc-types': 2.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/subscribable': 2.1.1(typescript@5.8.3)
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - ws
-
-  '@solana/rpc-subscriptions@4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@solana/errors': 4.0.0(typescript@5.8.3)
-      '@solana/fast-stable-stringify': 4.0.0(typescript@5.8.3)
-      '@solana/functional': 4.0.0(typescript@5.8.3)
-      '@solana/promises': 4.0.0(typescript@5.8.3)
-      '@solana/rpc-spec-types': 4.0.0(typescript@5.8.3)
-      '@solana/rpc-subscriptions-api': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/rpc-subscriptions-channel-websocket': 4.0.0(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/rpc-subscriptions-spec': 4.0.0(typescript@5.8.3)
-      '@solana/rpc-transformers': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/rpc-types': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/subscribable': 4.0.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -16254,23 +16208,6 @@ snapshots:
       '@solana/rpc-types': 2.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/transaction-messages': 2.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/transactions': 2.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - ws
-
-  '@solana/transaction-confirmation@4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@solana/addresses': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/codecs-strings': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/errors': 4.0.0(typescript@5.8.3)
-      '@solana/keys': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/promises': 4.0.0(typescript@5.8.3)
-      '@solana/rpc': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/rpc-subscriptions': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/rpc-types': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/transaction-messages': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/transactions': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,8 +26,8 @@ catalog:
   "@react-hookz/web": 25.1.1
   "@solana-mobile/wallet-adapter-mobile": ^2.2.4
   "@solana-program/token": ^0.5.1
-  "@solana/compat": ^4.0.0
-  "@solana/kit": ^4.0.0
+  "@solana/compat": 4.0.0
+  "@solana/kit": 4.0.0
   "@solana/spl-token": ^0.4.13
   "@solana/wallet-adapter-backpack": 0.1.14
   "@solana/wallet-adapter-base": 0.9.27


### PR DESCRIPTION
This change shows native token balance in the session widget and adds a stopgap mechanism for enabling native transfers, by allowing transactions to be signed with the wallet instead of the session.

The UX here has some downsides:

1. The wallet will show a big scary warning message about the transaction being untrusted
2. The wallet will show SOL instead of FOGO as the token being transferred
3. Currently I haven't added the necessary changes to enable sending tokens using this new mechanism (but this is something I can do in a follow-up if we decide to move forward on this)

However, despite these downsides, this will allow users to interact with native tokens even before sessions can actually support them, so we might consider this as a temporary stopgap solution.