### PR TITLE
feat: add activity tab with a link to fogo explorer

### DIFF
--- a/.changeset/light-zebras-rhyme.md
+++ b/.changeset/light-zebras-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@fogo/sessions-sdk-react": patch
+---
+
+Add activity tab with a link to fogo explorer for now

--- a/apps/sessions-demo/next-env.d.ts
+++ b/apps/sessions-demo/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/sessions-sdk-react/src/components/explorer-link.tsx
+++ b/packages/sessions-sdk-react/src/components/explorer-link.tsx
@@ -32,7 +32,7 @@ const mkLink = (network: Network, chain: Chain, txHash: string) => {
     case Network.Mainnet: {
       return chain === Chain.Solana
         ? `https://solscan.io/tx/${txHash}`
-        : `https://explorer.fogo.io/tx/${txHash}?cluster=mainnet-beta`;
+        : `https://fogoscan.com/tx/${txHash}?cluster=mainnet`;
     }
     case Network.Testnet: {
       return chain === Chain.Solana

--- a/packages/sessions-sdk-react/src/components/session-panel.module.scss
+++ b/packages/sessions-sdk-react/src/components/session-panel.module.scss
@@ -92,6 +92,27 @@
 
     .tabPanel {
       overflow: hidden;
+
+      .activity {
+        padding: theme.spacing(14) theme.spacing(8);
+        text-align: center;
+        display: flex;
+        flex-flow: column nowrap;
+        gap: theme.spacing(4);
+
+        .activityHeader {
+          @include theme.text("xl", "medium");
+
+          color: theme.color("heading");
+          margin-bottom: theme.spacing(8);
+        }
+
+        .activityMessage {
+          @include theme.text("base");
+
+          color: theme.color("paragraph");
+        }
+      }
     }
 
     .footer {

--- a/packages/sessions-sdk-react/src/components/session-panel.tsx
+++ b/packages/sessions-sdk-react/src/components/session-panel.tsx
@@ -18,6 +18,7 @@ import { CopyButton } from "./copy-button.js";
 import { DepositPage } from "./deposit-page.js";
 import { FogoWordmark } from "./fogo-wordmark.js";
 import { GetTokensPage } from "./get-tokens-page.js";
+import { Link } from "./link.js";
 import { ReceivePage } from "./receive-page.js";
 import { SelectTokenPage } from "./select-token-page.js";
 import { SendTokenPage } from "./send-token-page.js";
@@ -64,8 +65,41 @@ export const SessionPanel = ({ onClose, className, ...props }: Props) => {
           </Button>
         )}
       </div>
-      {whitelistedTokens.length === 0 ? (
-        <div className={styles.tabPanel}>
+      <Tabs className={styles.tabs ?? ""}>
+        <TabList
+          aria-label="Wallet"
+          className={styles.tabList ?? ""}
+          items={[
+            { id: "tokens", name: "Tokens" },
+            { id: "activity", name: "Activity" },
+            ...(whitelistedTokens.length === 0
+              ? []
+              : [{ id: "session-limits", name: "Session" }]),
+          ]}
+        >
+          {({ id, name }) => (
+            <Tab className={styles.tab ?? ""} id={id}>
+              {({ isSelected }) => (
+                <>
+                  <span>{name}</span>
+                  {isSelected && (
+                    <motion.span
+                      layoutId="underline"
+                      className={styles.underline}
+                      transition={{
+                        type: "spring",
+                        bounce: 0.6,
+                        duration: 0.6,
+                      }}
+                      style={{ originY: "top" }}
+                    />
+                  )}
+                </>
+              )}
+            </Tab>
+          )}
+        </TabList>
+        <TabPanel className={styles.tabPanel ?? ""} id="tokens">
           {isEstablished(sessionState) && (
             <Tokens
               sessionState={sessionState}
@@ -73,48 +107,13 @@ export const SessionPanel = ({ onClose, className, ...props }: Props) => {
               setCurrentScreen={setCurrentScreen}
             />
           )}
-        </div>
-      ) : (
-        <Tabs className={styles.tabs ?? ""}>
-          <TabList
-            aria-label="Wallet"
-            className={styles.tabList ?? ""}
-            items={[
-              { id: "tokens", name: "Tokens" },
-              { id: "session-limits", name: "Session" },
-            ]}
-          >
-            {({ id, name }) => (
-              <Tab className={styles.tab ?? ""} id={id}>
-                {({ isSelected }) => (
-                  <>
-                    <span>{name}</span>
-                    {isSelected && (
-                      <motion.span
-                        layoutId="underline"
-                        className={styles.underline}
-                        transition={{
-                          type: "spring",
-                          bounce: 0.6,
-                          duration: 0.6,
-                        }}
-                        style={{ originY: "top" }}
-                      />
-                    )}
-                  </>
-                )}
-              </Tab>
-            )}
-          </TabList>
-          <TabPanel className={styles.tabPanel ?? ""} id="tokens">
-            {isEstablished(sessionState) && (
-              <Tokens
-                sessionState={sessionState}
-                currentScreen={currentScreen}
-                setCurrentScreen={setCurrentScreen}
-              />
-            )}
-          </TabPanel>
+        </TabPanel>
+        <TabPanel className={styles.tabPanel ?? ""} id="activity">
+          {isEstablished(sessionState) && (
+            <Activity sessionState={sessionState} />
+          )}
+        </TabPanel>
+        {whitelistedTokens.length > 0 && (
           <TabPanel
             className={styles.tabPanel ?? ""}
             id="session-limits"
@@ -124,8 +123,8 @@ export const SessionPanel = ({ onClose, className, ...props }: Props) => {
               <SessionLimitsTab sessionState={sessionState} />
             )}
           </TabPanel>
-        </Tabs>
-      )}
+        )}
+      </Tabs>
       <div className={styles.footer}>
         <FogoWordmark className={styles.fogoWordmark} />
         <LogoutButton sessionState={sessionState} onLogout={onClose} />
@@ -133,6 +132,28 @@ export const SessionPanel = ({ onClose, className, ...props }: Props) => {
     </div>
   );
 };
+
+const Activity = ({
+  sessionState,
+}: {
+  sessionState: EstablishedSessionState;
+}) => (
+  <div className={styles.activity}>
+    <p className={styles.activityMessage}>
+      Transaction history is coming to Fogo Sessions.
+    </p>
+    <p className={styles.activityMessage}>
+      In the meantime, you can see your transaction history on{" "}
+      <Link
+        target="_blank"
+        href={`https://fogoscan.com/account/${sessionState.walletPublicKey.toBase58()}#transfers`}
+      >
+        the Fogo explorer
+      </Link>
+      .
+    </p>
+  </div>
+);
 
 const LogoutButton = ({
   sessionState,


### PR DESCRIPTION
This is a temporary stopgap that links users to the Fogo explorer for activity against their wallet.  We'll replace this with a proper activity history when we have some index somewhere that includes tx history for a wallet along with token accounts

<img width="710" height="1138" alt="screenshot-2025-12-02-143751" src="https://github.com/user-attachments/assets/e6f1cbdf-fe0c-4f8d-be72-1ef56f4910d3" />
