### PR TITLE
chore: enable npm trusted publishing

### DIFF
--- a/.github/workflows/knope-release.yaml
+++ b/.github/workflows/knope-release.yaml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   publish:


### PR DESCRIPTION
see https://docs.npmjs.com/trusted-publishers