### PR TITLE
chore: fix Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1922,7 +1922,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fogo-paymaster"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "anchor-lang",
  "anyhow",


### PR DESCRIPTION
This was failing in CI jobs, e.g. https://github.com/fogo-foundation/fogo-sessions/actions/runs/19948065615/job/57201998699