### PR TITLE
chore: make batch span processor configurable

### DIFF
--- a/services/paymaster/src/main.rs
+++ b/services/paymaster/src/main.rs
@@ -3,7 +3,7 @@ use arc_swap::ArcSwap;
 use clap::Parser;
 use opentelemetry::trace::TracerProvider;
 use opentelemetry_otlp::WithExportConfig;
-use opentelemetry_sdk::trace::{BatchConfig, BatchConfigBuilder};
+use opentelemetry_sdk::trace::BatchConfigBuilder;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};


### PR DESCRIPTION
This PR makes the BatchSpanProcessor (responsible for sending spans to the telemetry exporter) configurable via the en variables: 
- OTEL_BSP_MAX_CONCURRENT_EXPORTS
- OTEL_BSP_MAX_QUEUE_SIZE
- OTEL_BSP_SCHEDULE_DELAY
- OTEL_BSP_MAX_EXPORT_BATCH_SIZE
