### PR TITLE
chore: clean parsing

### DIFF
--- a/packages/solana-intents/src/key_value.rs
+++ b/packages/solana-intents/src/key_value.rs
@@ -2,7 +2,7 @@ use nom::{
     branch::alt,
     bytes::complete::{tag, take_while1},
     character::complete::{char, line_ending, not_line_ending},
-    combinator::{eof, map, map_opt, opt, recognize},
+    combinator::{eof, map, map_opt, recognize},
     error::ParseError,
     multi::many0,
     sequence::{delimited, preceded, separated_pair},


### PR DESCRIPTION
I'd like to further simplify parsing by enforcing that for a multiline value in the intent message, it may only be a list with each item starting by `-`.

This solves some ambiguous cases there are now like: `foo: \nbar` is interpreted as `{key: "foo", value: ""}` but `foo:\nbar` is interpreted as `{key: "foo", value: "bar"}`