### PR TITLE
fix: fixed biome not properly throwing errors in CI when issues are detected. created a simple wrapper binfile to make this easier

### DIFF
--- a/bin/biome-ci
+++ b/bin/biome-ci
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+if [ ! "$CI" ]; then
+  biome check --staged --no-errors-on-unmatched --max-diagnostics=none "$@"
+  biome check --changed --no-errors-on-unmatched --max-diagnostics=none "$@"
+else
+  # CI: always check changed files
+  biome ci --changed --no-errors-on-unmatched --max-diagnostics=none "$@"
+fi

--- a/package.json
+++ b/package.json
@@ -7,15 +7,16 @@
     "pnpm": "^10.25.0"
   },
   "scripts": {
-    "fix:lint": "biome check --write --changed --no-errors-on-unmatched; biome check --write --staged --no-errors-on-unmatched",
-    "fix:lint:unsafe": "biome check --write --unsafe --changed --no-errors-on-unmatched; biome check --write --unsafe --staged --no-errors-on-unmatched",
+    "fix:lint": "biome-ci --write",
+    "fix:lint:unsafe": "biome-ci --write --unsafe",
     "install:modules": "[ $CI ] && true || pnpm install",
+    "prepare": "./scripts/ci/npm-prepare.sh",
     "run:domain-registry": "domain-registry",
     "run:initialize-chain-id": "initialize-chain-id",
     "run:register-ntt-manager": "register-ntt-manager",
     "run:register-fee-config": "register-fee-config",
     "run:update-metadata": "update-metadata",
-    "test:lint": "biome ci --changed --no-errors-on-unmatched; if [ ! $CI ]; then biome check --staged --no-errors-on-unmatched; fi",
+    "test:lint": "biome-ci",
     "turbo": "[ ! -d node_modules ] && pnpm install; turbo"
   },
   "devDependencies": {

--- a/scripts/ci/npm-prepare.sh
+++ b/scripts/ci/npm-prepare.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+THISDIR="$(dirname "$0")"
+INPUT_BIN_DIR="$(realpath "$THISDIR/../../bin")"
+OUTPUT_BIN_DIR="$(realpath "$THISDIR/../../node_modules/.bin")"
+
+for file in "$INPUT_BIN_DIR"/*; do
+  if [ -f "$file" ]; then
+    bn="$(basename "$file")"
+    echo "creating node_modules binfile symlink for '$bn'"
+    ln -s "$file" "$OUTPUT_BIN_DIR/$bn" || true
+  fi
+done


### PR DESCRIPTION
Moving forward, use `biome-ci` when running any biome commands on the CLI / terminal. This will use our simple wrapper binfile and determine which set of biome commands are best to use, based on your environment 👍 