### PR TITLE
fix: paymaster valiant tx include fee

### DIFF
--- a/services/paymaster/src/swap.rs
+++ b/services/paymaster/src/swap.rs
@@ -274,6 +274,7 @@ impl ValiantClient {
             pools,
             is_exact_in: true,
             use_alt: true,
+            // TODO: roll this back to false once Valiant fixes their API
             include_fee: true,
         };
 


### PR DESCRIPTION
This PR includes the fee in the valiant api call because that is necessary to create any intermediate ATAs. I've left a TODO note indicating we should roll this back to `include_fee: false` once Valiant fixes this in their API.