### PR TITLE
fix(paymaster-admin): V0 variation UI

### DIFF
--- a/apps/paymaster-admin/src/components/Variation/variation-code-block.tsx
+++ b/apps/paymaster-admin/src/components/Variation/variation-code-block.tsx
@@ -87,7 +87,9 @@ export const VariationCodeBlock = ({
               />
             )}
           </div>
-          {footer && <div className={styles.variationCodeBlockFooter}>{footer}</div>}
+          {footer && (
+            <div className={styles.variationCodeBlockFooter}>{footer}</div>
+          )}
         </motion.div>
       )}
     </AnimatePresence>

--- a/apps/paymaster-admin/src/components/Variation/variations-list-item.tsx
+++ b/apps/paymaster-admin/src/components/Variation/variations-list-item.tsx
@@ -86,7 +86,8 @@ const VariationForm = ({
         : generateEditableToml(variation?.transaction_variation ?? []);
     return {
       name: variation?.name ?? "",
-      maxGasSpend: variation?.version === "v1" ? variation.max_gas_spend.toString() : "",
+      maxGasSpend:
+        variation?.version === "v1" ? variation.max_gas_spend.toString() : "",
       code: variationCode,
     };
   }, [
@@ -95,7 +96,7 @@ const VariationForm = ({
     variation?.version,
     variation?.transaction_variation,
     isEditingJson,
-    variation?.version === "v1" ? variation.max_gas_spend.toString() : ""
+    variation?.version === "v1" ? variation.max_gas_spend.toString() : "",
   ]);
 
   const resetForm = useCallback(() => {
@@ -303,37 +304,39 @@ const VariationForm = ({
         value={code}
         onChange={handleCodeChange}
         footer={
-          (!variation || variation?.version === "v1") && <>
-            <div className={styles.variationFormFooterActions}>
-              <Button variant="ghost" onClick={handleEditJsonClick} size="sm">
-                {isEditingJson ? "TOML" : "JSON"}
-              </Button>
-              {codeError || state.type === StateType.Error ? (
-                <p className={styles.variationFormFooterError}>
-                  {state.type === StateType.Error
-                    ? errorToString(state.error)
-                    : codeError}
-                </p>
+          (!variation || variation?.version === "v1") && (
+            <>
+              <div className={styles.variationFormFooterActions}>
+                <Button variant="ghost" onClick={handleEditJsonClick} size="sm">
+                  {isEditingJson ? "TOML" : "JSON"}
+                </Button>
+                {codeError || state.type === StateType.Error ? (
+                  <p className={styles.variationFormFooterError}>
+                    {state.type === StateType.Error
+                      ? errorToString(state.error)
+                      : codeError}
+                  </p>
+                ) : (
+                  <Badge variant="success" size="xs">
+                    All passed <ChecksIcon />
+                  </Badge>
+                )}
+              </div>
+              {isDirty ? (
+                <Button
+                  variant="secondary"
+                  type="submit"
+                  isDisabled={state.type === StateType.Running || !!codeError}
+                >
+                  {state.type === StateType.Running ? "Saving..." : "Save"}
+                </Button>
               ) : (
-                <Badge variant="success" size="xs">
-                  All passed <ChecksIcon />
-                </Badge>
+                <Button variant="ghost" onClick={handleCloseClick}>
+                  Dismiss
+                </Button>
               )}
-            </div>
-            {isDirty ? (
-              <Button
-                variant="secondary"
-                type="submit"
-                isDisabled={state.type === StateType.Running || !!codeError}
-              >
-                {state.type === StateType.Running ? "Saving..." : "Save"}
-              </Button>
-            ) : (
-              <Button variant="ghost" onClick={handleCloseClick}>
-                Dismiss
-              </Button>
-            )}
-          </>
+            </>
+          )
         }
       />
     </Form>


### PR DESCRIPTION
V1 (unchanged):
<img width="1639" height="564" alt="Screenshot 2026-01-27 at 15 07 19" src="https://github.com/user-attachments/assets/062e4fd5-caec-43f3-946b-21afa867189c" />

V0 (changed) - we don't want to support this at all, so just displaying it read only: 
<img width="1635" height="563" alt="Screenshot 2026-01-27 at 15 06 53" src="https://github.com/user-attachments/assets/d1ce8b87-7513-42fd-95e7-94bba0489d03" />
