### PR TITLE
Stub `usePrices` for now

### DIFF
--- a/.changeset/silence_errors_from_fetching_token_price.md
+++ b/.changeset/silence_errors_from_fetching_token_price.md
@@ -1,0 +1,5 @@
+---
+@fogo/sessions-sdk-react: patch
+---
+
+# Silence errors from fetching token price

--- a/packages/component-library/src/useData/index.ts
+++ b/packages/component-library/src/useData/index.ts
@@ -34,7 +34,7 @@ export enum StateType {
   Error,
 }
 
-const State = {
+export const State = {
   NotLoaded: <T>(mutate: KeyedMutator<T>) => ({
     type: StateType.NotLoaded as const,
     mutate,
@@ -51,6 +51,12 @@ const State = {
     reset,
   }),
 };
+
+export type State<T> =
+  | ReturnType<typeof State.NotLoaded<T>>
+  | ReturnType<typeof State.Loading>
+  | ReturnType<typeof State.Loaded<T>>
+  | ReturnType<typeof State.ErrorState>;
 
 class UseDataError extends Error {
   constructor(cause: unknown) {

--- a/packages/sessions-sdk-react/src/hooks/use-price.ts
+++ b/packages/sessions-sdk-react/src/hooks/use-price.ts
@@ -1,29 +1,5 @@
-import { useCallback } from "react";
-import { z } from "zod";
+import { State } from "../components/component-library/useData/index.js";
 
-import { useData } from "../components/component-library/useData/index.js";
-
-export const usePrice = (mint: string) => {
-  const getPriceData = useCallback(() => getPrice(mint), [mint]);
-
-  return useData(["price", mint], getPriceData, { refreshInterval: 2000 });
-};
-
-export const getPrice = async (mint: string) => {
-  const priceUrl = new URL("https://api.fogo.io/api/token-price");
-  priceUrl.searchParams.set("mint", mint);
-
-  const response = await fetch(priceUrl);
-  if (!response.ok) {
-    // Don't throw for now since the pricing data isn't yet implemented and this
-    // is just filling logs with noise.
-    return 0;
-    // throw new Error(
-    //   `Failed to fetch price: ${response.status.toString()} ${response.statusText}`,
-    // );
-  }
-
-  return priceSchema.parse(await response.json());
-};
-
-const priceSchema = z.number();
+// This is a dummy implementation for now, we will fill this in down the line
+// when we decide to revisit adding notional values.
+export const usePrice = (_mint: string): State<number> => State.Loading();


### PR DESCRIPTION
This is adding a ton of error logs to the console errors because the `/token-price` endpoint was never implemented, and it's pretty painful to debug other stuff.  We still might come back and add notional values to the widget, so for now I'm just going to stub this method.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fogo-foundation/fogo-sessions/pull/612" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
