### PR TITLE
chore: fix incorrect type in NonZeroUsize expect message

### DIFF
--- a/scripts/paymaster-load-test/src/config.rs
+++ b/scripts/paymaster-load-test/src/config.rs
@@ -52,7 +52,7 @@ pub struct FileConfig {
 }
 
 fn default_one() -> NonZeroUsize {
-    NonZeroUsize::new(1).expect("non-zero u8 provided, should not panic")
+    NonZeroUsize::new(1).expect("non-zero usize provided, should not panic")
 }
 
 #[derive(Debug, Clone, Deserialize)]


### PR DESCRIPTION
Correct type in NonZeroUsize panic message.